### PR TITLE
[#19] Github Action 배포 설정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,9 +31,9 @@ jobs:
           touch ./application.yml
           echo "${{ secrets.APPLICATION_YAML }}" | base64 --decode > ./application.yml
         shell: bash
-      # Gradle 빌드
+      # Gradle 빌드 (테스트 제외)
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew clean build -x test
         shell: bash
       # DockerFile 이미지 작성 및 Docker Repository 업로드
       - name: Docker build & Docker push
@@ -53,4 +53,4 @@ jobs:
             docker stop $(docker ps -qa) 
             docker rm $(docker ps -qa) 
             docker pull ${{ secrets.USERNAME }}/modoospace
-            docker run -d -p 8080:8080 --name modoospace ${{ secrets.USERNAME }}/modoospace
+            docker run -d -p 8080:8080 --name modoocontainer ${{ secrets.USERNAME }}/modoospace

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,16 +1,14 @@
-name: CICD
+name: CD
 
 on:
   push:
     branches: [ "master" ]
-  pull_request:
-    branches: [ "develop" ]
 
 permissions:
   contents: read
 
 jobs:
-  CI:
+  CD:
     runs-on: ubuntu-latest
     # 작업 실행단계
     steps:
@@ -43,3 +41,16 @@ jobs:
          docker login -u ${{ secrets.USERNAME }} -p ${{ secrets.PASSWORD }}
          docker build -f Dockerfile -t ${{ secrets.USERNAME }}/modoospace .
          docker push ${{ secrets.USERNAME }}/modoospace
+      # 서버 접속 및 애플리케이션 실행
+      - name: WAS access & deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.WAS_HOST }}
+          username: ${{ secrets.WAS_USERNAME }}
+          key: ${{ secrets.WAS_PASSWORD }}
+          port: ${{ secrets.WAS_SSH_PORT }}
+          script: |
+            docker stop $(docker ps -qa) 
+            docker rm $(docker ps -qa) 
+            docker pull ${{ secrets.USERNAME }}/modoospace
+            docker run -d -p 8080:8080 --name modoospace ${{ secrets.USERNAME }}/modoospace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ "develop" ]
+
+permissions:
+  contents: read
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    # 작업 실행단계
+    steps:
+      # 체크아웃 및 JDK 세팅
+      - name : Checkout
+        uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      # Gradle 권한 부여
+      - name : Grant Execute permission for gradlew
+        run: chmod +x gradlew
+        shell: bash
+      # application.yml 파일 생성
+      - name: Make application.yml
+        run: |
+          cd ./src/main/resources
+          touch ./application.yml
+          echo "${{ secrets.APPLICATION_YAML }}" | base64 --decode > ./application.yml
+        shell: bash
+      # Gradle 빌드
+      - name: Build with Gradle
+        run: ./gradlew build
+        shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,5 @@ jobs:
         shell: bash
       # Gradle 빌드
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew clean build
         shell: bash


### PR DESCRIPTION
## 개요
Github Action 배포를 설정했습니다.

## 작업사항
- CI: develop 브랜치 pr이 일어날 경우 gradle build 실행
- CD: master 브랜치 push가 일어날 경우 gradle build(test 제외) ➡️ 도커파일 생성 후 허브 업로드 ➡️ 서버에서 도커파일 pull받은 후 어플리케이션 실행

## 변경로직
- CI와 CD를 분리했습니다.

