### PR TITLE
[#30] 목록 조회 기능 개선

### DIFF
--- a/src/main/java/com/modoospace/alarm/controller/AlarmController.java
+++ b/src/main/java/com/modoospace/alarm/controller/AlarmController.java
@@ -1,10 +1,11 @@
 package com.modoospace.alarm.controller;
 
-import com.modoospace.alarm.service.AlarmService;
 import com.modoospace.alarm.controller.dto.AlarmReadDto;
+import com.modoospace.alarm.service.AlarmService;
 import com.modoospace.config.auth.LoginEmail;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,8 +20,9 @@ public class AlarmController {
   private final AlarmService alarmService;
 
   @GetMapping()
-  public ResponseEntity<List<AlarmReadDto>> findAlarms(@LoginEmail String loginEmail) {
-    List<AlarmReadDto> alarms = alarmService.findAlarmsByMember(loginEmail);
+  public ResponseEntity<Page<AlarmReadDto>> search(@LoginEmail String loginEmail,
+      Pageable pageable) {
+    Page<AlarmReadDto> alarms = alarmService.searchAlarms(loginEmail, pageable);
     return ResponseEntity.ok().body(alarms);
   }
 

--- a/src/main/java/com/modoospace/alarm/controller/dto/AlarmEvent.java
+++ b/src/main/java/com/modoospace/alarm/controller/dto/AlarmEvent.java
@@ -2,7 +2,6 @@ package com.modoospace.alarm.controller.dto;
 
 import com.modoospace.alarm.domain.Alarm;
 import com.modoospace.alarm.domain.AlarmType;
-import com.modoospace.member.domain.Member;
 import com.modoospace.reservation.domain.Reservation;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
@@ -20,12 +19,16 @@ public class AlarmEvent {
   private Long reservationId;
 
   @NotNull
+  private String facilityName;
+
+  @NotNull
   private AlarmType alarmType;
 
   @Builder
-  public AlarmEvent(Long memberId, Long reservationId, AlarmType alarmType) {
+  public AlarmEvent(Long memberId, Long reservationId, String facilityName, AlarmType alarmType) {
     this.memberId = memberId;
     this.reservationId = reservationId;
+    this.facilityName = facilityName;
     this.alarmType = alarmType;
   }
 
@@ -33,6 +36,7 @@ public class AlarmEvent {
     return AlarmEvent.builder()
         .memberId(reservation.getHost().getId())
         .reservationId(reservation.getId())
+        .facilityName(reservation.getFacility().getFacilityName())
         .alarmType(AlarmType.NEW_RESERVATION)
         .build();
   }
@@ -41,6 +45,7 @@ public class AlarmEvent {
     return AlarmEvent.builder()
         .memberId(reservation.getVisitor().getId())
         .reservationId(reservation.getId())
+        .facilityName(reservation.getFacility().getFacilityName())
         .alarmType(AlarmType.APPROVED_RESERVATION)
         .build();
   }
@@ -49,14 +54,16 @@ public class AlarmEvent {
     return AlarmEvent.builder()
         .memberId(reservation.getHost().getId())
         .reservationId(reservation.getId())
+        .facilityName(reservation.getFacility().getFacilityName())
         .alarmType(AlarmType.CANCELED_RESERVATION)
         .build();
   }
 
-  public Alarm toEntity(Member member, Reservation reservation) {
+  public Alarm toEntity() {
     return Alarm.builder()
-        .member(member)
-        .reservation(reservation)
+        .memberId(memberId)
+        .reservationId(reservationId)
+        .facilityName(facilityName)
         .alarmType(alarmType)
         .build();
   }

--- a/src/main/java/com/modoospace/alarm/controller/dto/AlarmReadDto.java
+++ b/src/main/java/com/modoospace/alarm/controller/dto/AlarmReadDto.java
@@ -29,7 +29,7 @@ public class AlarmReadDto {
   public static AlarmReadDto toDto(Alarm alarm) {
     return AlarmReadDto.builder()
         .id(alarm.getId())
-        .reservationId(alarm.getReservation().getId())
+        .reservationId(alarm.getReservationId())
         .message(alarm.getAlarmMessage())
         .build();
   }

--- a/src/main/java/com/modoospace/alarm/domain/Alarm.java
+++ b/src/main/java/com/modoospace/alarm/domain/Alarm.java
@@ -1,17 +1,12 @@
 package com.modoospace.alarm.domain;
 
 import com.modoospace.common.BaseTimeEntity;
-import com.modoospace.member.domain.Member;
-import com.modoospace.reservation.domain.Reservation;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,27 +22,26 @@ public class Alarm extends BaseTimeEntity {
   @Column(name = "alarm_id")
   private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "member_id")
-  private Member member;
+  private Long memberId;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "reservation_id")
-  private Reservation reservation;
+  private Long reservationId;
+
+  private String facilityName;
 
   @Enumerated(EnumType.STRING)
   private AlarmType alarmType;
 
   @Builder
-  public Alarm(Long id, Member member, Reservation reservation,
+  public Alarm(Long id, Long memberId, Long reservationId, String facilityName,
       AlarmType alarmType) {
     this.id = id;
-    this.member = member;
-    this.reservation = reservation;
+    this.memberId = memberId;
+    this.reservationId = reservationId;
+    this.facilityName = facilityName;
     this.alarmType = alarmType;
   }
 
-  public String getAlarmMessage(){
-    return reservation.getFacility().getFacilityName() + alarmType.getAlarmText();
+  public String getAlarmMessage() {
+    return facilityName + alarmType.getAlarmText();
   }
 }

--- a/src/main/java/com/modoospace/alarm/domain/AlarmRepository.java
+++ b/src/main/java/com/modoospace/alarm/domain/AlarmRepository.java
@@ -1,11 +1,7 @@
 package com.modoospace.alarm.domain;
 
-import com.modoospace.member.domain.Member;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
-  List<Alarm> findByMember(Member member);
 }

--- a/src/main/java/com/modoospace/alarm/repository/AlarmQueryRepository.java
+++ b/src/main/java/com/modoospace/alarm/repository/AlarmQueryRepository.java
@@ -1,0 +1,42 @@
+package com.modoospace.alarm.repository;
+
+import static com.modoospace.alarm.domain.QAlarm.alarm;
+
+import com.modoospace.alarm.domain.Alarm;
+import com.modoospace.member.domain.Member;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class AlarmQueryRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  public Page<Alarm> searchByMember(Member member, Pageable pageable) {
+
+    List<Alarm> content = jpaQueryFactory
+        .selectFrom(alarm)
+        .where(memberIdEq(member.getId()))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    JPAQuery<Alarm> countQuery = jpaQueryFactory
+        .selectFrom(alarm)
+        .where(memberIdEq(member.getId()));
+
+    return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
+  }
+
+  private BooleanExpression memberIdEq(Long memberId) {
+    return memberId != null ? alarm.memberId.eq(memberId) : null;
+  }
+}

--- a/src/main/java/com/modoospace/space/controller/FacilityController.java
+++ b/src/main/java/com/modoospace/space/controller/FacilityController.java
@@ -3,11 +3,16 @@ package com.modoospace.space.controller;
 import com.modoospace.config.auth.LoginEmail;
 import com.modoospace.space.controller.dto.facility.FacilityCreateDto;
 import com.modoospace.space.controller.dto.facility.FacilityReadDetailDto;
+import com.modoospace.space.controller.dto.facility.FacilityReadDto;
+import com.modoospace.space.controller.dto.facility.FacilitySearchDto;
 import com.modoospace.space.controller.dto.facility.FacilityUpdateDto;
+import com.modoospace.space.domain.FacilityType;
 import com.modoospace.space.sevice.FacilityService;
 import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,6 +37,14 @@ public class FacilityController {
     Long facilityId = facilityService.createFacility(spaceId, createDto, loginEmail);
     return ResponseEntity
         .created(URI.create("/api/v1/spaces/" + spaceId + "/facilities/" + facilityId)).build();
+  }
+
+  @GetMapping()
+  public ResponseEntity<Page<FacilityReadDto>> search(@PathVariable Long spaceId,
+      FacilitySearchDto searchDto, Pageable pageable) {
+    Page<FacilityReadDto> facilityReadDtos = facilityService
+        .searchFacility(spaceId, searchDto, pageable);
+    return ResponseEntity.ok().body(facilityReadDtos);
   }
 
   @GetMapping("/{facilityId}")

--- a/src/main/java/com/modoospace/space/controller/SpaceController.java
+++ b/src/main/java/com/modoospace/space/controller/SpaceController.java
@@ -3,14 +3,13 @@ package com.modoospace.space.controller;
 import com.modoospace.config.auth.LoginEmail;
 import com.modoospace.space.controller.dto.space.SpaceCreateUpdateDto;
 import com.modoospace.space.controller.dto.space.SpaceReadDto;
+import com.modoospace.space.controller.dto.space.SpaceSearchDto;
 import com.modoospace.space.sevice.SpaceService;
 import java.net.URI;
-import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,16 +35,9 @@ public class SpaceController {
     return ResponseEntity.created(URI.create("/api/v1/spaces/" + spaceId)).build();
   }
 
-  @GetMapping("/category/{categoryId}")
-  public ResponseEntity<List<SpaceReadDto>> findByCategory(@PathVariable Long categoryId) {
-    List<SpaceReadDto> spaceReadDtos = spaceService.findSpaceByCategory(categoryId);
-    return ResponseEntity.ok().body(spaceReadDtos);
-  }
-
-  @GetMapping("/host/{hostId}")
-  public ResponseEntity<Page<SpaceReadDto>> findByHost(@PathVariable Long hostId,
-      @PageableDefault Pageable pageable) {
-    Page<SpaceReadDto> spaceReadDtos = spaceService.findSpaceByHost(hostId, pageable);
+  @GetMapping()
+  public ResponseEntity<Page<SpaceReadDto>> search(SpaceSearchDto searchDto, Pageable pageable) {
+    Page<SpaceReadDto> spaceReadDtos = spaceService.searchSpace(searchDto, pageable);
     return ResponseEntity.ok().body(spaceReadDtos);
   }
 

--- a/src/main/java/com/modoospace/space/controller/dto/facility/FacilitySearchDto.java
+++ b/src/main/java/com/modoospace/space/controller/dto/facility/FacilitySearchDto.java
@@ -1,0 +1,27 @@
+package com.modoospace.space.controller.dto.facility;
+
+import com.modoospace.space.domain.FacilityType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * query string 형식으로 dto를 받기 위해서는 setter 필요
+ */
+@Getter @Setter
+@NoArgsConstructor
+public class FacilitySearchDto {
+
+  private String name;
+
+  private FacilityType facilityType;
+
+  private Boolean reservationEnable;
+
+  public FacilitySearchDto(String name, FacilityType facilityType,
+      Boolean reservationEnable) {
+    this.name = name;
+    this.facilityType = facilityType;
+    this.reservationEnable = reservationEnable;
+  }
+}

--- a/src/main/java/com/modoospace/space/controller/dto/space/SpaceSearchDto.java
+++ b/src/main/java/com/modoospace/space/controller/dto/space/SpaceSearchDto.java
@@ -1,27 +1,33 @@
 package com.modoospace.space.controller.dto.space;
 
-import javax.validation.constraints.NotEmpty;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class SpaceSearchDto {
 
-  @NotEmpty
+  private String name;
+
   private String depthFirst;
 
-  @NotEmpty
   private String depthSecond;
 
-  @NotEmpty
   private String depthThird;
 
-  @Builder
-  public SpaceSearchDto(String depthFirst, String depthSecond, String depthThird) {
+  private Long hostId;
+
+  private Long categoryId;
+
+  public SpaceSearchDto(String name, String depthFirst, String depthSecond,
+      String depthThird, Long hostId, Long categoryId) {
+    this.name = name;
     this.depthFirst = depthFirst;
     this.depthSecond = depthSecond;
     this.depthThird = depthThird;
+    this.hostId = hostId;
+    this.categoryId = categoryId;
   }
 }

--- a/src/main/java/com/modoospace/space/repository/FacilityQueryRepository.java
+++ b/src/main/java/com/modoospace/space/repository/FacilityQueryRepository.java
@@ -45,8 +45,7 @@ public class FacilityQueryRepository {
         .fetch();
 
     JPAQuery<Facility> countQuery = jpaQueryFactory
-        .select(facility)
-        .from(facility)
+        .selectFrom(facility)
         .where(spaceIdEq(spaceId)
             , nameContains(searchDto.getName())
             , facilityTypeEq(searchDto.getFacilityType())

--- a/src/main/java/com/modoospace/space/repository/FacilityQueryRepository.java
+++ b/src/main/java/com/modoospace/space/repository/FacilityQueryRepository.java
@@ -1,0 +1,73 @@
+package com.modoospace.space.repository;
+
+import static com.modoospace.space.domain.QFacility.facility;
+
+import com.modoospace.space.controller.dto.facility.FacilityReadDto;
+import com.modoospace.space.controller.dto.facility.FacilitySearchDto;
+import com.modoospace.space.domain.Facility;
+import com.modoospace.space.domain.FacilityType;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class FacilityQueryRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  public Page<FacilityReadDto> searchFacility(Long spaceId, FacilitySearchDto searchDto,
+      Pageable pageable) {
+
+    List<FacilityReadDto> content = jpaQueryFactory
+        .select(
+            Projections.constructor(FacilityReadDto.class
+                , facility.id
+                , facility.name
+                , facility.facilityType
+                , facility.reservationEnable
+                , facility.description)
+        )
+        .from(facility)
+        .where(spaceIdEq(spaceId)
+            , nameContains(searchDto.getName())
+            , facilityTypeEq(searchDto.getFacilityType())
+            , reservationEnableEq(searchDto.getReservationEnable()))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    JPAQuery<Facility> countQuery = jpaQueryFactory
+        .select(facility)
+        .from(facility)
+        .where(spaceIdEq(spaceId)
+            , nameContains(searchDto.getName())
+            , facilityTypeEq(searchDto.getFacilityType())
+            , reservationEnableEq(searchDto.getReservationEnable()));
+
+    return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
+  }
+
+  private BooleanExpression spaceIdEq(Long spaceId) {
+    return spaceId != null ? facility.space.id.eq(spaceId) : null;
+  }
+
+  private BooleanExpression nameContains(String name) {
+    return name != null ? facility.name.contains(name) : null;
+  }
+
+  private BooleanExpression facilityTypeEq(FacilityType facilityType) {
+    return facilityType != null ? facility.facilityType.eq(facilityType) : null;
+  }
+
+  private BooleanExpression reservationEnableEq(Boolean reservationEnable) {
+    return reservationEnable != null ? facility.reservationEnable.eq(reservationEnable) : null;
+  }
+}

--- a/src/main/java/com/modoospace/space/repository/SpaceQueryRepository.java
+++ b/src/main/java/com/modoospace/space/repository/SpaceQueryRepository.java
@@ -1,0 +1,78 @@
+package com.modoospace.space.repository;
+
+import static com.modoospace.member.domain.QMember.member;
+import static com.modoospace.space.domain.QCategory.category;
+import static com.modoospace.space.domain.QSpace.space;
+
+import com.modoospace.space.controller.dto.space.SpaceSearchDto;
+import com.modoospace.space.domain.Space;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class SpaceQueryRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  public Page<Space> searchSpace(SpaceSearchDto searchDto, Pageable pageable) {
+
+    List<Space> content = jpaQueryFactory
+        .selectFrom(space)
+        .join(space.host, member).fetchJoin()
+        .join(space.category, category).fetchJoin()
+        .where(nameContains(searchDto.getName())
+            , depthFirstEq(searchDto.getDepthFirst())
+            , depthSecondEq(searchDto.getDepthSecond())
+            , depthThirdEq(searchDto.getDepthThird())
+            , hostIdEq(searchDto.getHostId())
+            , categoryIdEq(searchDto.getCategoryId())
+        )
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    JPAQuery<Space> countQuery = jpaQueryFactory
+        .selectFrom(space)
+        .where(nameContains(searchDto.getName())
+            , depthFirstEq(searchDto.getDepthFirst())
+            , depthSecondEq(searchDto.getDepthSecond())
+            , depthThirdEq(searchDto.getDepthThird())
+            , hostIdEq(searchDto.getHostId())
+            , categoryIdEq(searchDto.getCategoryId())
+        );
+
+    return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
+  }
+
+  private BooleanExpression nameContains(String name) {
+    return name != null ? space.name.contains(name) : null;
+  }
+
+  private BooleanExpression depthFirstEq(String depthFirst) {
+    return depthFirst != null ? space.address.depthFirst.eq(depthFirst) : null;
+  }
+
+  private BooleanExpression depthSecondEq(String depthSecond) {
+    return depthSecond != null ? space.address.depthSecond.eq(depthSecond) : null;
+  }
+
+  private BooleanExpression depthThirdEq(String depthThird) {
+    return depthThird != null ? space.address.depthThird.eq(depthThird) : null;
+  }
+
+  private BooleanExpression hostIdEq(Long hostId) {
+    return hostId != null ? space.host.id.eq(hostId) : null;
+  }
+
+  private BooleanExpression categoryIdEq(Long categoryId) {
+    return categoryId != null ? space.category.id.eq(categoryId) : null;
+  }
+}

--- a/src/main/java/com/modoospace/space/sevice/FacilityService.java
+++ b/src/main/java/com/modoospace/space/sevice/FacilityService.java
@@ -5,12 +5,17 @@ import com.modoospace.member.domain.Member;
 import com.modoospace.member.domain.MemberRepository;
 import com.modoospace.space.controller.dto.facility.FacilityCreateDto;
 import com.modoospace.space.controller.dto.facility.FacilityReadDetailDto;
+import com.modoospace.space.controller.dto.facility.FacilityReadDto;
+import com.modoospace.space.controller.dto.facility.FacilitySearchDto;
 import com.modoospace.space.controller.dto.facility.FacilityUpdateDto;
 import com.modoospace.space.domain.Facility;
 import com.modoospace.space.domain.FacilityRepository;
 import com.modoospace.space.domain.Space;
 import com.modoospace.space.domain.SpaceRepository;
+import com.modoospace.space.repository.FacilityQueryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +26,7 @@ public class FacilityService {
   private final MemberRepository memberRepository;
   private final SpaceRepository spaceRepository;
   private final FacilityRepository facilityRepository;
+  private final FacilityQueryRepository facilityQueryRepository;
 
   @Transactional
   public Long createFacility(Long spaceId, FacilityCreateDto createDto, String loginEmail) {
@@ -32,6 +38,11 @@ public class FacilityService {
     facilityRepository.save(facility);
 
     return facility.getId();
+  }
+
+  public Page<FacilityReadDto> searchFacility(Long spaceId, FacilitySearchDto searchDto,
+      Pageable pageable) {
+    return facilityQueryRepository.searchFacility(spaceId, searchDto, pageable);
   }
 
   public FacilityReadDetailDto findFacility(Long facilityId) {

--- a/src/main/java/com/modoospace/space/sevice/SpaceService.java
+++ b/src/main/java/com/modoospace/space/sevice/SpaceService.java
@@ -5,11 +5,12 @@ import com.modoospace.member.domain.Member;
 import com.modoospace.member.domain.MemberRepository;
 import com.modoospace.space.controller.dto.space.SpaceCreateUpdateDto;
 import com.modoospace.space.controller.dto.space.SpaceReadDto;
+import com.modoospace.space.controller.dto.space.SpaceSearchDto;
 import com.modoospace.space.domain.Category;
 import com.modoospace.space.domain.CategoryRepository;
 import com.modoospace.space.domain.Space;
 import com.modoospace.space.domain.SpaceRepository;
-import java.util.List;
+import com.modoospace.space.repository.SpaceQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +24,7 @@ public class SpaceService {
   private final MemberRepository memberRepository;
   private final SpaceRepository spaceRepository;
   private final CategoryRepository categoryRepository;
+  private final SpaceQueryRepository spaceQueryRepository;
 
   @Transactional
   public Long createSpace(Long categoryId, SpaceCreateUpdateDto createDto, String loginEmail) {
@@ -35,16 +37,8 @@ public class SpaceService {
     return space.getId();
   }
 
-  public List<SpaceReadDto> findSpaceByCategory(Long categoryId) {
-    // TODO : 페이징처리가 필요합니다.
-    Category category = findCategoryById(categoryId);
-    List<Space> spaces = spaceRepository.findByCategory(category);
-
-    return SpaceReadDto.toDtos(spaces);
-  }
-
-  public Page<SpaceReadDto> findSpaceByHost(Long hostId, Pageable pageable) {
-    Page<Space> spaces = spaceRepository.findByHostId(hostId, pageable);
+  public Page<SpaceReadDto> searchSpace(SpaceSearchDto searchDto, Pageable pageable) {
+    Page<Space> spaces = spaceQueryRepository.searchSpace(searchDto, pageable);
 
     return spaces.map(space -> SpaceReadDto.toDto(space));
   }

--- a/src/main/java/com/modoospace/space/sevice/SpaceService.java
+++ b/src/main/java/com/modoospace/space/sevice/SpaceService.java
@@ -40,7 +40,7 @@ public class SpaceService {
   public Page<SpaceReadDto> searchSpace(SpaceSearchDto searchDto, Pageable pageable) {
     Page<Space> spaces = spaceQueryRepository.searchSpace(searchDto, pageable);
 
-    return spaces.map(space -> SpaceReadDto.toDto(space));
+    return spaces.map(SpaceReadDto::toDto);
   }
 
   public SpaceReadDto findSpace(Long spaceId) {

--- a/src/test/java/com/modoospace/TestConfig.java
+++ b/src/test/java/com/modoospace/TestConfig.java
@@ -1,6 +1,7 @@
 package com.modoospace;
 
 import com.modoospace.reservation.repository.ReservationQueryRepository;
+import com.modoospace.space.repository.FacilityQueryRepository;
 import com.modoospace.space.repository.FacilityScheduleQueryRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import javax.persistence.EntityManager;
@@ -22,6 +23,11 @@ public class TestConfig {
   @Bean
   public ReservationQueryRepository reservationQueryRepository() {
     return new ReservationQueryRepository(jpaQueryFactory());
+  }
+
+  @Bean
+  public FacilityQueryRepository facilityQueryRepository() {
+    return new FacilityQueryRepository(jpaQueryFactory());
   }
 
   @Bean

--- a/src/test/java/com/modoospace/TestConfig.java
+++ b/src/test/java/com/modoospace/TestConfig.java
@@ -3,6 +3,7 @@ package com.modoospace;
 import com.modoospace.reservation.repository.ReservationQueryRepository;
 import com.modoospace.space.repository.FacilityQueryRepository;
 import com.modoospace.space.repository.FacilityScheduleQueryRepository;
+import com.modoospace.space.repository.SpaceQueryRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -23,6 +24,11 @@ public class TestConfig {
   @Bean
   public ReservationQueryRepository reservationQueryRepository() {
     return new ReservationQueryRepository(jpaQueryFactory());
+  }
+
+  @Bean
+  public SpaceQueryRepository spaceQueryRepository() {
+    return new SpaceQueryRepository(jpaQueryFactory());
   }
 
   @Bean

--- a/src/test/java/com/modoospace/space/repository/FacilityQueryRepositoryTest.java
+++ b/src/test/java/com/modoospace/space/repository/FacilityQueryRepositoryTest.java
@@ -1,0 +1,113 @@
+package com.modoospace.space.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.modoospace.TestConfig;
+import com.modoospace.member.domain.Member;
+import com.modoospace.member.domain.MemberRepository;
+import com.modoospace.member.domain.Role;
+import com.modoospace.space.controller.dto.facility.FacilityCreateDto;
+import com.modoospace.space.controller.dto.facility.FacilityReadDto;
+import com.modoospace.space.controller.dto.facility.FacilitySearchDto;
+import com.modoospace.space.controller.dto.space.SpaceCreateUpdateDto;
+import com.modoospace.space.domain.Category;
+import com.modoospace.space.domain.CategoryRepository;
+import com.modoospace.space.domain.FacilityRepository;
+import com.modoospace.space.domain.FacilityType;
+import com.modoospace.space.domain.Space;
+import com.modoospace.space.domain.SpaceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(TestConfig.class)
+@ActiveProfiles("test")
+public class FacilityQueryRepositoryTest {
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Autowired
+  private CategoryRepository categoryRepository;
+
+  @Autowired
+  private SpaceRepository spaceRepository;
+
+  @Autowired
+  private FacilityRepository facilityRepository;
+
+  @Autowired
+  private FacilityQueryRepository facilityQueryRepository;
+
+  private Space space;
+
+  @BeforeEach
+  public void setUp() {
+    Member hostMember = Member.builder()
+        .email("host@email")
+        .name("host")
+        .role(Role.HOST)
+        .build();
+    memberRepository.save(hostMember);
+
+    Category category = Category.builder()
+        .name("스터디 공간")
+        .build();
+    categoryRepository.save(category);
+
+    SpaceCreateUpdateDto spaceCreateDto = SpaceCreateUpdateDto.builder()
+        .name("공간이름")
+        .description("설명")
+        .build();
+    space = spaceCreateDto.toEntity(category, hostMember);
+    spaceRepository.save(space);
+
+    FacilityCreateDto createRoomDto = FacilityCreateDto.builder()
+        .name("스터디룸")
+        .facilityType(FacilityType.ROOM)
+        .description("1~4인실 입니다.")
+        .reservationEnable(true)
+        .build();
+    facilityRepository.save(createRoomDto.toEntity(space));
+    FacilityCreateDto createSeatDto = FacilityCreateDto.builder()
+        .name("스터디좌석")
+        .facilityType(FacilityType.SEAT)
+        .description("스터디좌석 입니다.")
+        .reservationEnable(true)
+        .build();
+    facilityRepository.save(createSeatDto.toEntity(space));
+  }
+
+  @DisplayName("검색 조건에 맞는 시설을 반환한다.")
+  @Test
+  public void searchFacility() {
+    FacilitySearchDto searchDto = new FacilitySearchDto();
+    searchDto.setName("스터디");
+    searchDto.setReservationEnable(true);
+
+    Page<FacilityReadDto> resultPage = facilityQueryRepository
+        .searchFacility(space.getId(), searchDto, PageRequest.of(0, 10));
+
+    assertThat(resultPage.getContent()).extracting("name")
+        .containsExactly("스터디룸", "스터디좌석");
+  }
+
+  @DisplayName("검색 조건에 맞는 시설이 없다면 빈 페이지를 반환한다.")
+  @Test
+  public void searchFacility_emptyPage() {
+    FacilitySearchDto searchDto = new FacilitySearchDto();
+    searchDto.setReservationEnable(false);
+
+    Page<FacilityReadDto> resultPage = facilityQueryRepository
+        .searchFacility(space.getId(), searchDto, PageRequest.of(0, 10));
+
+    assertThat(resultPage.getContent()).isEmpty();
+  }
+}

--- a/src/test/java/com/modoospace/space/sevice/FacilityScheduleServiceTest.java
+++ b/src/test/java/com/modoospace/space/sevice/FacilityScheduleServiceTest.java
@@ -23,6 +23,7 @@ import com.modoospace.space.domain.FacilityScheduleRepository;
 import com.modoospace.space.domain.FacilityType;
 import com.modoospace.space.domain.Space;
 import com.modoospace.space.domain.SpaceRepository;
+import com.modoospace.space.repository.FacilityScheduleQueryRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -57,6 +58,9 @@ public class FacilityScheduleServiceTest {
   @Autowired
   private FacilityScheduleRepository facilityScheduleRepository;
 
+  @Autowired
+  private FacilityScheduleQueryRepository facilityScheduleQueryRepository;
+
   private FacilityScheduleService facilityScheduleService;
 
   private Member hostMember;
@@ -72,7 +76,7 @@ public class FacilityScheduleServiceTest {
   @BeforeEach
   public void setUp() {
     facilityScheduleService = new FacilityScheduleService(memberRepository, facilityRepository,
-        facilityScheduleRepository);
+        facilityScheduleRepository, facilityScheduleQueryRepository);
 
     hostMember = Member.builder()
         .email("host@email")

--- a/src/test/java/com/modoospace/space/sevice/FacilityServiceTest.java
+++ b/src/test/java/com/modoospace/space/sevice/FacilityServiceTest.java
@@ -19,6 +19,7 @@ import com.modoospace.space.domain.FacilityRepository;
 import com.modoospace.space.domain.FacilityType;
 import com.modoospace.space.domain.Space;
 import com.modoospace.space.domain.SpaceRepository;
+import com.modoospace.space.repository.FacilityQueryRepository;
 import com.modoospace.space.repository.FacilityScheduleQueryRepository;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -56,13 +57,16 @@ class FacilityServiceTest {
   @Autowired
   private FacilityScheduleQueryRepository facilityScheduleQueryRepository;
 
+  @Autowired
+  private FacilityQueryRepository facilityQueryRepository;
+
   private Member hostMember;
   private Space space;
   private LocalDate nowDate;
 
   @BeforeEach
   public void setUp() {
-    facilityService = new FacilityService(memberRepository, spaceRepository, facilityRepository);
+    facilityService = new FacilityService(memberRepository, spaceRepository, facilityRepository, facilityQueryRepository);
 
     hostMember = Member.builder()
         .email("host@email")

--- a/src/test/java/com/modoospace/space/sevice/SpaceServiceTest.java
+++ b/src/test/java/com/modoospace/space/sevice/SpaceServiceTest.java
@@ -12,10 +12,12 @@ import com.modoospace.member.domain.MemberRepository;
 import com.modoospace.member.domain.Role;
 import com.modoospace.space.controller.dto.space.SpaceCreateUpdateDto;
 import com.modoospace.space.controller.dto.space.SpaceReadDto;
+import com.modoospace.space.controller.dto.space.SpaceSearchDto;
 import com.modoospace.space.domain.Address;
 import com.modoospace.space.domain.Category;
 import com.modoospace.space.domain.CategoryRepository;
 import com.modoospace.space.domain.SpaceRepository;
+import com.modoospace.space.repository.SpaceQueryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,6 +46,9 @@ class SpaceServiceTest {
   @Autowired
   private CategoryRepository categoryRepository;
 
+  @Autowired
+  private SpaceQueryRepository spaceQueryRepository;
+
   private Member hostMember;
   private Member visitorMember;
   private Member adminMember;
@@ -53,7 +58,8 @@ class SpaceServiceTest {
 
   @BeforeEach
   public void setUp() {
-    spaceService = new SpaceService(memberRepository, spaceRepository, categoryRepository);
+    spaceService = new SpaceService(memberRepository, spaceRepository, categoryRepository,
+        spaceQueryRepository);
 
     hostMember = Member.builder()
         .email("host@email")
@@ -191,7 +197,7 @@ class SpaceServiceTest {
 
   @DisplayName("호스트ID로 호스트가 소유하고있는 공간을 조회할 수 있다.")
   @Test
-  public void findSpaceByHost() {
+  public void searchSpaceByHostId() {
     spaceService.createSpace(category.getId(), createDto, hostMember.getEmail());
     createDto = SpaceCreateUpdateDto.builder()
         .name("공간이름2")
@@ -200,8 +206,10 @@ class SpaceServiceTest {
     spaceService.createSpace(category.getId(), createDto, hostMember.getEmail());
 
     PageRequest pageRequest = PageRequest.of(0, 10);
+    SpaceSearchDto searchDto = new SpaceSearchDto();
+    searchDto.setHostId(hostMember.getId());
     Page<SpaceReadDto> retPage = spaceService
-        .findSpaceByHost(hostMember.getId(), pageRequest);
+        .searchSpace(searchDto, pageRequest);
 
     assertThat(retPage.isFirst()).isTrue();
     assertThat(retPage.getTotalElements()).isEqualTo(2);


### PR DESCRIPTION
## 개요
목록 조회에 필요한 동적쿼리생성 및 페이징처리를 진행하였으며, 해당 도메인에 적절한 개선점을 찾아 수정하였습니다.

## 작업사항
- Space 목록 조회 : 동적쿼리, 페이징처리, fetchJoin을 통해 쿼리 한번으로 조회가능하도록 변경
- Facility 목록 조회 : 동적쿼리, 페이징처리, 생성자 Projections를 통해 DTO로 바로 조회가능하도록 변경
- Alarm 목록 조회 : 엔티티 연관관계 제거 및 알람 메시지를 저장하도록 변경, 페이징 처리

## 변경로직
- FacilitySchedule 조회에 필요한 로직을 repository로 옮김.

