### PR TITLE
[#36 알람 서비스 SSE 및 Login Session Redis 적용]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ dependencies {
 	// RabbitMQ
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis'
+
 	//queryDsl
 	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
 	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"

--- a/src/main/java/com/modoospace/config/RedisConfig.java
+++ b/src/main/java/com/modoospace/config/RedisConfig.java
@@ -1,0 +1,40 @@
+package com.modoospace.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+  @Value("${spring.redis.host}")
+  private String host;
+  @Value("${spring.redis.port}")
+  private int port;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
+    return new LettuceConnectionFactory(configuration);
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(
+      RedisConnectionFactory redisConnectionFactory) {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+    // key : value
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+    return redisTemplate;
+  }
+}


### PR DESCRIPTION
## 개요
알람 서비스 SSE 및 Login Session Redis 적용

## 작업사항
- Redis 환경 구축

## 변경로직
- 로그인 시 사용되는 Session 저장소 Redis로 변경
- SSE Inmemory map ➡️ Redis로 변경
> SSE 테스트는 프론트화면이 필요해보임.

