### PR TITLE
[#36] Alarm Redis 적용 및 Alarm삭제 기능 추가

### DIFF
--- a/src/main/java/com/modoospace/MainController.java
+++ b/src/main/java/com/modoospace/MainController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 @RequiredArgsConstructor
 @Controller
 public class MainController {
+
   @GetMapping({"", "/"})
   public String index(Model model, @LoginEmail String loginEmail) {
     if (loginEmail != null) {

--- a/src/main/java/com/modoospace/ModoospaceApplication.java
+++ b/src/main/java/com/modoospace/ModoospaceApplication.java
@@ -2,14 +2,15 @@ package com.modoospace;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableCaching
 @EnableJpaAuditing
 @SpringBootApplication
 public class ModoospaceApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ModoospaceApplication.class, args);
-	}
-
+  public static void main(String[] args) {
+    SpringApplication.run(ModoospaceApplication.class, args);
+  }
 }

--- a/src/main/java/com/modoospace/alarm/controller/AlarmController.java
+++ b/src/main/java/com/modoospace/alarm/controller/AlarmController.java
@@ -7,7 +7,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -24,6 +26,13 @@ public class AlarmController {
       Pageable pageable) {
     Page<AlarmReadDto> alarms = alarmService.searchAlarms(loginEmail, pageable);
     return ResponseEntity.ok().body(alarms);
+  }
+
+  @DeleteMapping("/{alarmId}")
+  public ResponseEntity<Void> delete(@PathVariable Long alarmId,
+      @LoginEmail String loginEmail) {
+    alarmService.delete(alarmId, loginEmail);
+    return ResponseEntity.noContent().build();
   }
 
   @GetMapping("/subscribe")

--- a/src/main/java/com/modoospace/alarm/controller/dto/AlarmEvent.java
+++ b/src/main/java/com/modoospace/alarm/controller/dto/AlarmEvent.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class AlarmEvent {
 
   @NotNull
-  private Long memberId;
+  private String email;
 
   @NotNull
   private Long reservationId;
@@ -25,8 +25,8 @@ public class AlarmEvent {
   private AlarmType alarmType;
 
   @Builder
-  public AlarmEvent(Long memberId, Long reservationId, String facilityName, AlarmType alarmType) {
-    this.memberId = memberId;
+  public AlarmEvent(String email, Long reservationId, String facilityName, AlarmType alarmType) {
+    this.email = email;
     this.reservationId = reservationId;
     this.facilityName = facilityName;
     this.alarmType = alarmType;
@@ -34,7 +34,7 @@ public class AlarmEvent {
 
   public static AlarmEvent toNewReservationAlarm(Reservation reservation) {
     return AlarmEvent.builder()
-        .memberId(reservation.getHost().getId())
+        .email(reservation.getHost().getEmail())
         .reservationId(reservation.getId())
         .facilityName(reservation.getFacility().getFacilityName())
         .alarmType(AlarmType.NEW_RESERVATION)
@@ -43,7 +43,7 @@ public class AlarmEvent {
 
   public static AlarmEvent toApprovedReservationAlarm(Reservation reservation) {
     return AlarmEvent.builder()
-        .memberId(reservation.getVisitor().getId())
+        .email(reservation.getVisitor().getEmail())
         .reservationId(reservation.getId())
         .facilityName(reservation.getFacility().getFacilityName())
         .alarmType(AlarmType.APPROVED_RESERVATION)
@@ -52,7 +52,7 @@ public class AlarmEvent {
 
   public static AlarmEvent toCancelReservationAlarm(Reservation reservation) {
     return AlarmEvent.builder()
-        .memberId(reservation.getHost().getId())
+        .email(reservation.getHost().getEmail())
         .reservationId(reservation.getId())
         .facilityName(reservation.getFacility().getFacilityName())
         .alarmType(AlarmType.CANCELED_RESERVATION)
@@ -61,7 +61,7 @@ public class AlarmEvent {
 
   public Alarm toEntity() {
     return Alarm.builder()
-        .memberId(memberId)
+        .email(email)
         .reservationId(reservationId)
         .facilityName(facilityName)
         .alarmType(alarmType)

--- a/src/main/java/com/modoospace/alarm/controller/dto/AlarmReadDto.java
+++ b/src/main/java/com/modoospace/alarm/controller/dto/AlarmReadDto.java
@@ -1,6 +1,7 @@
 package com.modoospace.alarm.controller.dto;
 
 import com.modoospace.alarm.domain.AlarmType;
+import java.io.Serializable;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class AlarmReadDto {
+public class AlarmReadDto implements Serializable {
 
   @NotNull
   private Long id;

--- a/src/main/java/com/modoospace/alarm/controller/dto/AlarmReadDto.java
+++ b/src/main/java/com/modoospace/alarm/controller/dto/AlarmReadDto.java
@@ -1,6 +1,6 @@
 package com.modoospace.alarm.controller.dto;
 
-import com.modoospace.alarm.domain.Alarm;
+import com.modoospace.alarm.domain.AlarmType;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,17 +20,9 @@ public class AlarmReadDto {
   private String message;
 
   @Builder
-  public AlarmReadDto(Long id, Long reservationId, String message) {
+  public AlarmReadDto(Long id, Long reservationId, String facilityName, AlarmType alarmType) {
     this.id = id;
     this.reservationId = reservationId;
-    this.message = message;
-  }
-
-  public static AlarmReadDto toDto(Alarm alarm) {
-    return AlarmReadDto.builder()
-        .id(alarm.getId())
-        .reservationId(alarm.getReservationId())
-        .message(alarm.getAlarmMessage())
-        .build();
+    this.message = facilityName + alarmType.getAlarmText();
   }
 }

--- a/src/main/java/com/modoospace/alarm/domain/Alarm.java
+++ b/src/main/java/com/modoospace/alarm/domain/Alarm.java
@@ -1,6 +1,7 @@
 package com.modoospace.alarm.domain;
 
 import com.modoospace.common.BaseTimeEntity;
+import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Alarm extends BaseTimeEntity {
+public class Alarm extends BaseTimeEntity implements Serializable {
 
   @Id
   @GeneratedValue

--- a/src/main/java/com/modoospace/alarm/domain/Alarm.java
+++ b/src/main/java/com/modoospace/alarm/domain/Alarm.java
@@ -1,6 +1,8 @@
 package com.modoospace.alarm.domain;
 
 import com.modoospace.common.BaseTimeEntity;
+import com.modoospace.member.domain.Member;
+import com.modoospace.member.domain.Role;
 import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -23,7 +25,7 @@ public class Alarm extends BaseTimeEntity implements Serializable {
   @Column(name = "alarm_id")
   private Long id;
 
-  private Long memberId;
+  private String email;
 
   private Long reservationId;
 
@@ -33,10 +35,10 @@ public class Alarm extends BaseTimeEntity implements Serializable {
   private AlarmType alarmType;
 
   @Builder
-  public Alarm(Long id, Long memberId, Long reservationId, String facilityName,
+  public Alarm(Long id, String email, Long reservationId, String facilityName,
       AlarmType alarmType) {
     this.id = id;
-    this.memberId = memberId;
+    this.email = email;
     this.reservationId = reservationId;
     this.facilityName = facilityName;
     this.alarmType = alarmType;
@@ -44,5 +46,12 @@ public class Alarm extends BaseTimeEntity implements Serializable {
 
   public String getAlarmMessage() {
     return facilityName + alarmType.getAlarmText();
+  }
+
+  public void verifyManagementPermission(Member loginMember) {
+    if (email.equals(loginMember.getEmail())) {
+      return;
+    }
+    loginMember.verifyRolePermission(Role.ADMIN);
   }
 }

--- a/src/main/java/com/modoospace/alarm/domain/Alarm.java
+++ b/src/main/java/com/modoospace/alarm/domain/Alarm.java
@@ -3,7 +3,6 @@ package com.modoospace.alarm.domain;
 import com.modoospace.common.BaseTimeEntity;
 import com.modoospace.member.domain.Member;
 import com.modoospace.member.domain.Role;
-import java.io.Serializable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -18,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Alarm extends BaseTimeEntity implements Serializable {
+public class Alarm extends BaseTimeEntity {
 
   @Id
   @GeneratedValue
@@ -42,10 +41,6 @@ public class Alarm extends BaseTimeEntity implements Serializable {
     this.reservationId = reservationId;
     this.facilityName = facilityName;
     this.alarmType = alarmType;
-  }
-
-  public String getAlarmMessage() {
-    return facilityName + alarmType.getAlarmText();
   }
 
   public void verifyManagementPermission(Member loginMember) {

--- a/src/main/java/com/modoospace/alarm/repository/AlarmQueryRepository.java
+++ b/src/main/java/com/modoospace/alarm/repository/AlarmQueryRepository.java
@@ -21,12 +21,12 @@ public class AlarmQueryRepository {
 
   private final JPAQueryFactory jpaQueryFactory;
 
-  @Cacheable(cacheNames = "searchAlarms", key = "#member.id +':'+ #pageable.pageNumber")
+  @Cacheable(cacheNames = "searchAlarms", key = "#member.email +':'+ #pageable.pageNumber")
   public Page<Alarm> searchByMember(Member member, Pageable pageable) {
 
     List<Alarm> content = jpaQueryFactory
         .selectFrom(alarm)
-        .where(memberIdEq(member.getId()))
+        .where(emailEq(member.getEmail()))
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
         .orderBy(alarm.createdTime.desc())
@@ -34,12 +34,12 @@ public class AlarmQueryRepository {
 
     JPAQuery<Alarm> countQuery = jpaQueryFactory
         .selectFrom(alarm)
-        .where(memberIdEq(member.getId()));
+        .where(emailEq(member.getEmail()));
 
     return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
   }
 
-  private BooleanExpression memberIdEq(Long memberId) {
-    return memberId != null ? alarm.memberId.eq(memberId) : null;
+  private BooleanExpression emailEq(String email) {
+    return email != null ? alarm.email.eq(email) : null;
   }
 }

--- a/src/main/java/com/modoospace/alarm/repository/AlarmQueryRepository.java
+++ b/src/main/java/com/modoospace/alarm/repository/AlarmQueryRepository.java
@@ -9,6 +9,7 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -20,6 +21,7 @@ public class AlarmQueryRepository {
 
   private final JPAQueryFactory jpaQueryFactory;
 
+  @Cacheable(cacheNames = "searchAlarms", key = "#member.id +':'+ #pageable.pageNumber")
   public Page<Alarm> searchByMember(Member member, Pageable pageable) {
 
     List<Alarm> content = jpaQueryFactory
@@ -27,6 +29,7 @@ public class AlarmQueryRepository {
         .where(memberIdEq(member.getId()))
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
+        .orderBy(alarm.createdTime.desc())
         .fetch();
 
     JPAQuery<Alarm> countQuery = jpaQueryFactory

--- a/src/main/java/com/modoospace/alarm/repository/AlarmQueryRepository.java
+++ b/src/main/java/com/modoospace/alarm/repository/AlarmQueryRepository.java
@@ -2,8 +2,10 @@ package com.modoospace.alarm.repository;
 
 import static com.modoospace.alarm.domain.QAlarm.alarm;
 
+import com.modoospace.alarm.controller.dto.AlarmReadDto;
 import com.modoospace.alarm.domain.Alarm;
 import com.modoospace.member.domain.Member;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -22,10 +24,18 @@ public class AlarmQueryRepository {
   private final JPAQueryFactory jpaQueryFactory;
 
   @Cacheable(cacheNames = "searchAlarms", key = "#member.email +':'+ #pageable.pageNumber")
-  public Page<Alarm> searchByMember(Member member, Pageable pageable) {
+  public Page<AlarmReadDto> searchByMember(Member member, Pageable pageable) {
 
-    List<Alarm> content = jpaQueryFactory
-        .selectFrom(alarm)
+    List<AlarmReadDto> content = jpaQueryFactory
+        .select(
+            Projections.constructor(AlarmReadDto.class
+                , alarm.id
+                , alarm.reservationId
+                , alarm.facilityName
+                , alarm.alarmType
+            )
+        )
+        .from(alarm)
         .where(emailEq(member.getEmail()))
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())

--- a/src/main/java/com/modoospace/alarm/repository/EmitterCacheRepository.java
+++ b/src/main/java/com/modoospace/alarm/repository/EmitterCacheRepository.java
@@ -49,6 +49,6 @@ public class EmitterCacheRepository {
   }
 
   private String getKey(String loginEmail) {
-    return "SSE: " + loginEmail;
+    return "SSE:" + loginEmail;
   }
 }

--- a/src/main/java/com/modoospace/alarm/service/AlarmService.java
+++ b/src/main/java/com/modoospace/alarm/service/AlarmService.java
@@ -77,10 +77,10 @@ public class AlarmService {
 
   @Transactional
   @CachePrefixEvict(cacheNames = "searchAlarms", key = "#loginEmail")
-  public void delete(String loginEmail, Long alarmId) {
+  public void delete(Long alarmId, String loginEmail) {
     Member loginMember = memberService.findMemberByEmail(loginEmail);
     Alarm alarm = findAlarmById(alarmId);
-    
+
     alarm.verifyManagementPermission(loginMember);
     alarmRepository.delete(alarm);
   }

--- a/src/main/java/com/modoospace/alarm/service/AlarmService.java
+++ b/src/main/java/com/modoospace/alarm/service/AlarmService.java
@@ -34,9 +34,8 @@ public class AlarmService {
 
   public Page<AlarmReadDto> searchAlarms(String loginEmail, Pageable pageable) {
     Member loginMember = memberService.findMemberByEmail(loginEmail);
-    Page<Alarm> alarms = alarmQueryRepository.searchByMember(loginMember, pageable);
 
-    return alarms.map(AlarmReadDto::toDto);
+    return alarmQueryRepository.searchByMember(loginMember, pageable);
   }
 
   public SseEmitter connectAlarm(String loginEmail) {

--- a/src/main/java/com/modoospace/alarm/service/AlarmService.java
+++ b/src/main/java/com/modoospace/alarm/service/AlarmService.java
@@ -7,6 +7,7 @@ import com.modoospace.alarm.domain.AlarmRepository;
 import com.modoospace.alarm.repository.AlarmQueryRepository;
 import com.modoospace.alarm.repository.EmitterCacheRepository;
 import com.modoospace.common.exception.SSEConnectError;
+import com.modoospace.config.redis.CachePrefixEvict;
 import com.modoospace.member.domain.Member;
 import com.modoospace.member.service.MemberService;
 import java.io.IOException;
@@ -51,6 +52,7 @@ public class AlarmService {
   }
 
   @Transactional
+  @CachePrefixEvict(cacheNames = "searchAlarms", key = "#{alarmEvent.memberId}")
   public void saveAndSend(AlarmEvent alarmEvent) {
     Member member = memberService.findMemberById(alarmEvent.getMemberId());
     Alarm alarm = alarmRepository.save(alarmEvent.toEntity());

--- a/src/main/java/com/modoospace/alarm/service/AlarmService.java
+++ b/src/main/java/com/modoospace/alarm/service/AlarmService.java
@@ -52,7 +52,7 @@ public class AlarmService {
   }
 
   @Transactional
-  @CachePrefixEvict(cacheNames = "searchAlarms", key = "#{alarmEvent.memberId}")
+  @CachePrefixEvict(cacheNames = "searchAlarms", key = "#alarmEvent.memberId")
   public void saveAndSend(AlarmEvent alarmEvent) {
     Member member = memberService.findMemberById(alarmEvent.getMemberId());
     Alarm alarm = alarmRepository.save(alarmEvent.toEntity());

--- a/src/main/java/com/modoospace/common/CustomSpELParser.java
+++ b/src/main/java/com/modoospace/common/CustomSpELParser.java
@@ -1,4 +1,4 @@
-package com.modoospace.common.SpELParser;
+package com.modoospace.common;
 
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -13,7 +13,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
 /**
- * Custom Annotation의 SpEL표현을 Parser하는 클래스
+ * Custom Annotation의 SpEL표현 Parser 클래스
  */
 public class CustomSpELParser {
 
@@ -32,7 +32,7 @@ public class CustomSpELParser {
     }
 
     // case2 : #value
-    return getValue(expression, createVariableContext(parameterNames, args));
+    return getValue(expression, createContextAndSetVariable(parameterNames, args));
   }
 
   private static Object getValueOfInstanceFiled(String[] parameterNames, Object[] args,
@@ -40,8 +40,9 @@ public class CustomSpELParser {
     int index = IntStream.range(0, parameterNames.length)
         .filter(i -> instanceName.equals(parameterNames[i]))
         .findFirst()
-        .orElseThrow(() -> new SpelEvaluationException(
-            SpelMessage.PROPERTY_OR_FIELD_NOT_READABLE_ON_NULL, instanceName));
+        .orElseThrow(
+            () -> new SpelEvaluationException(SpelMessage.PROPERTY_OR_FIELD_NOT_READABLE_ON_NULL,
+                instanceName));
 
     return getValue(fieldName, createRootObjectContext(args[index]));
   }
@@ -50,7 +51,7 @@ public class CustomSpELParser {
     return new StandardEvaluationContext(object);
   }
 
-  private static EvaluationContext createVariableContext(String[] parameterNames, Object[] args) {
+  private static EvaluationContext createContextAndSetVariable(String[] parameterNames, Object[] args) {
     EvaluationContext context = new StandardEvaluationContext();
     IntStream.range(0, parameterNames.length)
         .forEach(i -> context.setVariable(parameterNames[i], args[i]));
@@ -60,7 +61,8 @@ public class CustomSpELParser {
   private static Object getValue(String expression, EvaluationContext context) {
     Expression parseExpression = EXPRESSION_PARSER.parseExpression(expression);
     Optional<Object> value = Optional.ofNullable(parseExpression.getValue(context));
-    return value.orElseThrow(() -> new SpelEvaluationException(
-        SpelMessage.PROPERTY_OR_FIELD_NOT_READABLE_ON_NULL, expression));
+    return value.orElseThrow(
+        () -> new SpelEvaluationException(SpelMessage.PROPERTY_OR_FIELD_NOT_READABLE_ON_NULL,
+            expression));
   }
 }

--- a/src/main/java/com/modoospace/common/CustomSpELParser.java
+++ b/src/main/java/com/modoospace/common/CustomSpELParser.java
@@ -1,14 +1,10 @@
 package com.modoospace.common;
 
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
-import org.springframework.expression.spel.SpelEvaluationException;
-import org.springframework.expression.spel.SpelMessage;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
@@ -18,40 +14,14 @@ import org.springframework.expression.spel.support.StandardEvaluationContext;
 public class CustomSpELParser {
 
   private static final ExpressionParser EXPRESSION_PARSER = new SpelExpressionParser();
-  private static final Pattern INSTANCE_FILED_PATTERN = Pattern
-      .compile("#(\\w+)\\.(\\w+)");
 
   public static Object extractValueFromExpression(String[] parameterNames, Object[] args,
       String expression) {
-    Matcher instanceFieldMatcher = INSTANCE_FILED_PATTERN.matcher(expression);
-    // case1 : #instanceName.filedName
-    if (instanceFieldMatcher.find()) {
-      String instanceName = instanceFieldMatcher.group(1);
-      String fieldName = instanceFieldMatcher.group(2);
-      return getValueOfInstanceFiled(parameterNames, args, instanceName, fieldName);
-    }
-
-    // case2 : #value
     return getValue(expression, createContextAndSetVariable(parameterNames, args));
   }
 
-  private static Object getValueOfInstanceFiled(String[] parameterNames, Object[] args,
-      String instanceName, String fieldName) {
-    int index = IntStream.range(0, parameterNames.length)
-        .filter(i -> instanceName.equals(parameterNames[i]))
-        .findFirst()
-        .orElseThrow(
-            () -> new SpelEvaluationException(SpelMessage.PROPERTY_OR_FIELD_NOT_READABLE_ON_NULL,
-                instanceName));
-
-    return getValue(fieldName, createRootObjectContext(args[index]));
-  }
-
-  private static EvaluationContext createRootObjectContext(Object object) {
-    return new StandardEvaluationContext(object);
-  }
-
-  private static EvaluationContext createContextAndSetVariable(String[] parameterNames, Object[] args) {
+  private static EvaluationContext createContextAndSetVariable(String[] parameterNames,
+      Object[] args) {
     EvaluationContext context = new StandardEvaluationContext();
     IntStream.range(0, parameterNames.length)
         .forEach(i -> context.setVariable(parameterNames[i], args[i]));
@@ -61,8 +31,6 @@ public class CustomSpELParser {
   private static Object getValue(String expression, EvaluationContext context) {
     Expression parseExpression = EXPRESSION_PARSER.parseExpression(expression);
     Optional<Object> value = Optional.ofNullable(parseExpression.getValue(context));
-    return value.orElseThrow(
-        () -> new SpelEvaluationException(SpelMessage.PROPERTY_OR_FIELD_NOT_READABLE_ON_NULL,
-            expression));
+    return value.orElseThrow(() -> new NullPointerException(expression));
   }
 }

--- a/src/main/java/com/modoospace/common/DateFormatManager.java
+++ b/src/main/java/com/modoospace/common/DateFormatManager.java
@@ -1,5 +1,8 @@
 package com.modoospace.common;
 
+/**
+ * 날짜 포맷 관리 클래스
+ */
 public class DateFormatManager {
 
   public static final String YEARMONTH_FORMAT = "yyyy-MM";

--- a/src/main/java/com/modoospace/common/SpELParser/CustomSpELParser.java
+++ b/src/main/java/com/modoospace/common/SpELParser/CustomSpELParser.java
@@ -1,0 +1,66 @@
+package com.modoospace.common.SpELParser;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.IntStream;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.SpelEvaluationException;
+import org.springframework.expression.spel.SpelMessage;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+/**
+ * Custom Annotation의 SpEL표현을 Parser하는 클래스
+ */
+public class CustomSpELParser {
+
+  private static final ExpressionParser EXPRESSION_PARSER = new SpelExpressionParser();
+  private static final Pattern INSTANCE_FILED_PATTERN = Pattern
+      .compile("#(\\w+)\\.(\\w+)");
+
+  public static Object extractValueFromExpression(String[] parameterNames, Object[] args,
+      String expression) {
+    Matcher instanceFieldMatcher = INSTANCE_FILED_PATTERN.matcher(expression);
+    // case1 : #instanceName.filedName
+    if (instanceFieldMatcher.find()) {
+      String instanceName = instanceFieldMatcher.group(1);
+      String fieldName = instanceFieldMatcher.group(2);
+      return getValueOfInstanceFiled(parameterNames, args, instanceName, fieldName);
+    }
+
+    // case2 : #value
+    return getValue(expression, createVariableContext(parameterNames, args));
+  }
+
+  private static Object getValueOfInstanceFiled(String[] parameterNames, Object[] args,
+      String instanceName, String fieldName) {
+    int index = IntStream.range(0, parameterNames.length)
+        .filter(i -> instanceName.equals(parameterNames[i]))
+        .findFirst()
+        .orElseThrow(() -> new SpelEvaluationException(
+            SpelMessage.PROPERTY_OR_FIELD_NOT_READABLE_ON_NULL, instanceName));
+
+    return getValue(fieldName, createRootObjectContext(args[index]));
+  }
+
+  private static EvaluationContext createRootObjectContext(Object object) {
+    return new StandardEvaluationContext(object);
+  }
+
+  private static EvaluationContext createVariableContext(String[] parameterNames, Object[] args) {
+    EvaluationContext context = new StandardEvaluationContext();
+    IntStream.range(0, parameterNames.length)
+        .forEach(i -> context.setVariable(parameterNames[i], args[i]));
+    return context;
+  }
+
+  private static Object getValue(String expression, EvaluationContext context) {
+    Expression parseExpression = EXPRESSION_PARSER.parseExpression(expression);
+    Optional<Object> value = Optional.ofNullable(parseExpression.getValue(context));
+    return value.orElseThrow(() -> new SpelEvaluationException(
+        SpelMessage.PROPERTY_OR_FIELD_NOT_READABLE_ON_NULL, expression));
+  }
+}

--- a/src/main/java/com/modoospace/common/exception/AlarmSendException.java
+++ b/src/main/java/com/modoospace/common/exception/AlarmSendException.java
@@ -1,6 +1,6 @@
 package com.modoospace.common.exception;
 
-public class AlarmSendException extends RuntimeException{
+public class AlarmSendException extends RuntimeException {
 
   private static final String MESSAGE = "알람 전송에 실패했습니다.";
 

--- a/src/main/java/com/modoospace/common/exception/ConflictingTimeException.java
+++ b/src/main/java/com/modoospace/common/exception/ConflictingTimeException.java
@@ -9,7 +9,8 @@ public class ConflictingTimeException extends RuntimeException {
     super(timeSetting1 + "과 " + timeSetting2 + " 시간이 겹칩니다.");
   }
 
-  public ConflictingTimeException(FacilitySchedule facilitySchedule1, FacilitySchedule facilitySchedule2) {
+  public ConflictingTimeException(FacilitySchedule facilitySchedule1,
+      FacilitySchedule facilitySchedule2) {
     super(facilitySchedule1 + "과 " + facilitySchedule2 + " 시간이 겹칩니다.");
   }
 }

--- a/src/main/java/com/modoospace/common/exception/InvalidTimeRangeException.java
+++ b/src/main/java/com/modoospace/common/exception/InvalidTimeRangeException.java
@@ -10,6 +10,7 @@ public class InvalidTimeRangeException extends RuntimeException {
   }
 
   public InvalidTimeRangeException(LocalDateTime startDateTime, LocalDateTime endDateTime) {
-    super("시작시간(" + startDateTime.toString() + ") 은 종료시간(" + endDateTime.toString() + ") 보다 이후일 수 없습니다.");
+    super("시작시간(" + startDateTime.toString() + ") 은 종료시간(" + endDateTime.toString()
+        + ") 보다 이후일 수 없습니다.");
   }
 }

--- a/src/main/java/com/modoospace/common/exception/NotFoundEntityException.java
+++ b/src/main/java/com/modoospace/common/exception/NotFoundEntityException.java
@@ -1,12 +1,12 @@
 package com.modoospace.common.exception;
 
-public class NotFoundEntityException extends RuntimeException{
+public class NotFoundEntityException extends RuntimeException {
 
   public NotFoundEntityException(String entity, Long identifier) {
-    super("해당 " + entity + "("+identifier+") 을(를) 찾을 수 없습니다.");
+    super("해당 " + entity + "(" + identifier + ") 을(를) 찾을 수 없습니다.");
   }
 
   public NotFoundEntityException(String entity, String identifier) {
-    super("해당 " + entity + "("+identifier+") 을(를) 찾을 수 없습니다.");
+    super("해당 " + entity + "(" + identifier + ") 을(를) 찾을 수 없습니다.");
   }
 }

--- a/src/main/java/com/modoospace/common/exception/PermissionDeniedException.java
+++ b/src/main/java/com/modoospace/common/exception/PermissionDeniedException.java
@@ -1,6 +1,6 @@
 package com.modoospace.common.exception;
 
-public class PermissionDeniedException extends RuntimeException{
+public class PermissionDeniedException extends RuntimeException {
 
   private static final String MESSAGE = "권한이 없습니다.";
 

--- a/src/main/java/com/modoospace/common/exception/RedisProcessingException.java
+++ b/src/main/java/com/modoospace/common/exception/RedisProcessingException.java
@@ -7,8 +7,4 @@ public class RedisProcessingException extends RuntimeException {
   public RedisProcessingException() {
     super(MESSAGE);
   }
-
-  public RedisProcessingException(String message) {
-    super(message);
-  }
 }

--- a/src/main/java/com/modoospace/config/WebConfig.java
+++ b/src/main/java/com/modoospace/config/WebConfig.java
@@ -22,7 +22,7 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/**")
-            .allowedOrigins("*")
-            .allowedMethods("*");
+        .allowedOrigins("*")
+        .allowedMethods("*");
   }
 }

--- a/src/main/java/com/modoospace/config/redis/CachePrefixEvict.java
+++ b/src/main/java/com/modoospace/config/redis/CachePrefixEvict.java
@@ -8,6 +8,8 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CachePrefixEvict {
+
   String cacheNames();
+
   String key();
 }

--- a/src/main/java/com/modoospace/config/redis/CachePrefixEvict.java
+++ b/src/main/java/com/modoospace/config/redis/CachePrefixEvict.java
@@ -1,0 +1,13 @@
+package com.modoospace.config.redis;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CachePrefixEvict {
+  String cacheNames();
+  String key();
+}

--- a/src/main/java/com/modoospace/config/redis/CachePrefixEvictAdvisor.java
+++ b/src/main/java/com/modoospace/config/redis/CachePrefixEvictAdvisor.java
@@ -1,0 +1,37 @@
+package com.modoospace.config.redis;
+
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CachePrefixEvictAdvisor {
+
+  private final RedisTemplate redisTemplate;
+
+  @Around("@annotation(com.modoospace.config.redis.CachePrefixEvict)")
+  public Object processCachePrefixEvict(ProceedingJoinPoint joinPoint) throws Throwable {
+    MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+    CachePrefixEvict annotation = methodSignature.getMethod().getAnnotation(CachePrefixEvict.class);
+
+    // TODO : SpEL로 넘어온값 해석하는 Parser 만들어줘야함.
+    log.info("cacheNames = {}, key = {} redis evict try", annotation.cacheNames(),
+        annotation.key());
+    Set<String> keys = redisTemplate.keys(annotation.key() + "*");
+    if (keys != null) {
+      log.info("{} clear complete", keys);
+      redisTemplate.delete(keys);
+    }
+
+    return joinPoint.proceed();
+  }
+}

--- a/src/main/java/com/modoospace/config/redis/CachePrefixEvictAdvisor.java
+++ b/src/main/java/com/modoospace/config/redis/CachePrefixEvictAdvisor.java
@@ -1,5 +1,6 @@
 package com.modoospace.config.redis;
 
+import com.modoospace.common.SpELParser.CustomSpELParser;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,9 +24,10 @@ public class CachePrefixEvictAdvisor {
     MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
     CachePrefixEvict annotation = methodSignature.getMethod().getAnnotation(CachePrefixEvict.class);
 
-    // TODO : SpEL로 넘어온값 해석하는 Parser 만들어줘야함.
-    log.info("cacheNames = {}, key = {} redis evict try", annotation.cacheNames(),
-        annotation.key());
+    String key = CustomSpELParser.extractValueFromExpression(
+        methodSignature.getParameterNames(), joinPoint.getArgs(), annotation.key()
+    ).toString();
+    log.info("cacheNames = {}, key = {} redis evict try", annotation.cacheNames(), key);
     Set<String> keys = redisTemplate.keys(annotation.key() + "*");
     if (keys != null) {
       log.info("{} clear complete", keys);

--- a/src/main/java/com/modoospace/config/redis/CachePrefixEvictAdvisor.java
+++ b/src/main/java/com/modoospace/config/redis/CachePrefixEvictAdvisor.java
@@ -2,33 +2,34 @@ package com.modoospace.config.redis;
 
 import com.modoospace.common.SpELParser.CustomSpELParser;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Aspect
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class CachePrefixEvictAdvisor {
 
-  private final RedisTemplate redisTemplate;
+  @Autowired
+  StringRedisTemplate redisTemplate;
 
   @Around("@annotation(com.modoospace.config.redis.CachePrefixEvict)")
   public Object processCachePrefixEvict(ProceedingJoinPoint joinPoint) throws Throwable {
     MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
     CachePrefixEvict annotation = methodSignature.getMethod().getAnnotation(CachePrefixEvict.class);
-
-    String key = CustomSpELParser.extractValueFromExpression(
+    Object prefix = CustomSpELParser.extractValueFromExpression(
         methodSignature.getParameterNames(), joinPoint.getArgs(), annotation.key()
-    ).toString();
-    log.info("cacheNames = {}, key = {} redis evict try", annotation.cacheNames(), key);
-    Set<String> keys = redisTemplate.keys(annotation.key() + "*");
+    );
+
+    String pattern = String.format("%s::%s:*", annotation.cacheNames(), prefix);
+    log.info("key pattern ({}) evict try in redis", pattern);
+    Set<String> keys = redisTemplate.keys(pattern);
     if (keys != null) {
       log.info("{} clear complete", keys);
       redisTemplate.delete(keys);

--- a/src/main/java/com/modoospace/config/redis/CachePrefixEvictAdvisor.java
+++ b/src/main/java/com/modoospace/config/redis/CachePrefixEvictAdvisor.java
@@ -1,6 +1,6 @@
 package com.modoospace.config.redis;
 
-import com.modoospace.common.SpELParser.CustomSpELParser;
+import com.modoospace.common.CustomSpELParser;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;

--- a/src/main/java/com/modoospace/config/redis/EmbeddedRedisConfig.java
+++ b/src/main/java/com/modoospace/config/redis/EmbeddedRedisConfig.java
@@ -1,4 +1,4 @@
-package com.modoospace.config;
+package com.modoospace.config.redis;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;

--- a/src/main/java/com/modoospace/config/redis/RedisConfig.java
+++ b/src/main/java/com/modoospace/config/redis/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.modoospace.config;
+package com.modoospace.config.redis;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/modoospace/member/repository/MemberCacheRepository.java
+++ b/src/main/java/com/modoospace/member/repository/MemberCacheRepository.java
@@ -48,6 +48,6 @@ public class MemberCacheRepository {
   }
 
   public String getKey(String email) {
-    return "MEMBER: " + email;
+    return "MEMBER:" + email;
   }
 }

--- a/src/main/java/com/modoospace/reservation/controller/AdminReservationController.java
+++ b/src/main/java/com/modoospace/reservation/controller/AdminReservationController.java
@@ -22,7 +22,7 @@ public class AdminReservationController {
 
   private final ReservationService reservationService;
 
-   @GetMapping("/visitor/{memberId}")
+  @GetMapping("/visitor/{memberId}")
   public ResponseEntity<List<ReservationReadDto>> findAllAsMember(@PathVariable Long memberId,
       @LoginEmail final String loginEmail) {
     List<ReservationReadDto> reservationList = reservationService

--- a/src/main/java/com/modoospace/reservation/controller/dto/ReservationReadDto.java
+++ b/src/main/java/com/modoospace/reservation/controller/dto/ReservationReadDto.java
@@ -48,7 +48,7 @@ public class ReservationReadDto {
     this.member = member;
   }
 
-  public static ReservationReadDto toDto(Reservation reservation){
+  public static ReservationReadDto toDto(Reservation reservation) {
     return ReservationReadDto.builder()
         .id(reservation.getId())
         .facility(FacilityReadDto.toDto(reservation.getFacility()))

--- a/src/main/java/com/modoospace/reservation/controller/dto/ReservationUpdateDto.java
+++ b/src/main/java/com/modoospace/reservation/controller/dto/ReservationUpdateDto.java
@@ -2,7 +2,6 @@ package com.modoospace.reservation.controller.dto;
 
 import com.modoospace.reservation.domain.Reservation;
 import com.modoospace.reservation.domain.ReservationStatus;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/modoospace/space/controller/FacilityController.java
+++ b/src/main/java/com/modoospace/space/controller/FacilityController.java
@@ -6,7 +6,6 @@ import com.modoospace.space.controller.dto.facility.FacilityReadDetailDto;
 import com.modoospace.space.controller.dto.facility.FacilityReadDto;
 import com.modoospace.space.controller.dto.facility.FacilitySearchDto;
 import com.modoospace.space.controller.dto.facility.FacilityUpdateDto;
-import com.modoospace.space.domain.FacilityType;
 import com.modoospace.space.sevice.FacilityService;
 import java.net.URI;
 import javax.validation.Valid;

--- a/src/main/java/com/modoospace/space/controller/dto/facility/FacilityCreateDto.java
+++ b/src/main/java/com/modoospace/space/controller/dto/facility/FacilityCreateDto.java
@@ -50,8 +50,8 @@ public class FacilityCreateDto {
   );
 
   public FacilityCreateDto(String name, FacilityType facilityType, Boolean reservationEnable,
-                           String description, List<TimeSettingCreateDto> timeSettings,
-                           List<WeekdaySettingCreateDto> weekdaySettings) {
+      String description, List<TimeSettingCreateDto> timeSettings,
+      List<WeekdaySettingCreateDto> weekdaySettings) {
     this.name = name;
     this.facilityType = facilityType;
     this.reservationEnable = reservationEnable;

--- a/src/main/java/com/modoospace/space/controller/dto/facility/FacilitySearchDto.java
+++ b/src/main/java/com/modoospace/space/controller/dto/facility/FacilitySearchDto.java
@@ -8,7 +8,8 @@ import lombok.Setter;
 /**
  * query string 형식으로 dto를 받기 위해서는 setter 필요
  */
-@Getter @Setter
+@Getter
+@Setter
 @NoArgsConstructor
 public class FacilitySearchDto {
 

--- a/src/test/java/com/modoospace/TestConfig.java
+++ b/src/test/java/com/modoospace/TestConfig.java
@@ -1,5 +1,6 @@
 package com.modoospace;
 
+import com.modoospace.alarm.repository.AlarmQueryRepository;
 import com.modoospace.reservation.repository.ReservationQueryRepository;
 import com.modoospace.space.repository.FacilityQueryRepository;
 import com.modoospace.space.repository.FacilityScheduleQueryRepository;
@@ -39,5 +40,10 @@ public class TestConfig {
   @Bean
   public FacilityScheduleQueryRepository facilityScheduleQueryRepository() {
     return new FacilityScheduleQueryRepository(jpaQueryFactory());
+  }
+
+  @Bean
+  public AlarmQueryRepository alarmQueryRepository() {
+    return new AlarmQueryRepository(jpaQueryFactory());
   }
 }

--- a/src/test/java/com/modoospace/alarm/repository/AlarmQueryRepositoryTest.java
+++ b/src/test/java/com/modoospace/alarm/repository/AlarmQueryRepositoryTest.java
@@ -1,0 +1,74 @@
+package com.modoospace.alarm.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.modoospace.TestConfig;
+import com.modoospace.alarm.controller.dto.AlarmEvent;
+import com.modoospace.alarm.controller.dto.AlarmReadDto;
+import com.modoospace.alarm.domain.AlarmRepository;
+import com.modoospace.alarm.domain.AlarmType;
+import com.modoospace.member.domain.Member;
+import com.modoospace.member.domain.MemberRepository;
+import com.modoospace.member.domain.Role;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(TestConfig.class)
+@ActiveProfiles("test")
+class AlarmQueryRepositoryTest {
+
+  @Autowired
+  private AlarmQueryRepository alarmQueryRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Autowired
+  private AlarmRepository alarmRepository;
+
+  private Member hostMember;
+
+  @BeforeEach
+  public void setUp() {
+    hostMember = Member.builder()
+        .email("host@email")
+        .name("host")
+        .role(Role.HOST)
+        .build();
+
+    memberRepository.save(hostMember);
+
+    for (int i = 0; i < 10; i++) {
+      AlarmEvent testEvent = AlarmEvent.builder()
+          .email(hostMember.getEmail())
+          .reservationId((long) i)
+          .facilityName("테스트 시설")
+          .alarmType(AlarmType.NEW_RESERVATION)
+          .build();
+      alarmRepository.save(testEvent.toEntity());
+    }
+  }
+
+  @DisplayName("로그인한 멤버의 알람을 조회한다.")
+  @Test
+  public void searchAlarms(){
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    Page<AlarmReadDto> alarmReadDtos = alarmQueryRepository.searchByMember(hostMember, pageRequest);
+
+    List<AlarmReadDto> retContent = alarmReadDtos.getContent();
+
+    assertThat(retContent).hasSize(10);
+    for (AlarmReadDto alarmReadDto : retContent) {
+      System.out.println("alarmReadDto = " + alarmReadDto.getMessage());
+    }
+  }
+}

--- a/src/test/java/com/modoospace/alarm/service/AlarmServiceTest.java
+++ b/src/test/java/com/modoospace/alarm/service/AlarmServiceTest.java
@@ -1,0 +1,65 @@
+package com.modoospace.alarm.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.modoospace.alarm.controller.dto.AlarmEvent;
+import com.modoospace.alarm.controller.dto.AlarmReadDto;
+import com.modoospace.alarm.domain.AlarmType;
+import com.modoospace.member.domain.Member;
+import com.modoospace.member.domain.MemberRepository;
+import com.modoospace.member.domain.Role;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class AlarmServiceTest {
+
+  @Autowired
+  private AlarmService alarmService;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Autowired
+  private StringRedisTemplate redisTemplate;
+
+  private Member hostMember;
+
+  @BeforeEach
+  public void setUp() {
+    hostMember = Member.builder()
+        .email("host@email")
+        .name("host")
+        .role(Role.HOST)
+        .build();
+
+    memberRepository.save(hostMember);
+  }
+
+  @DisplayName("알람을 새로 save하면 redis에 저장되어있던 해당 멤버의 알람 페이징 데이터가 전부 삭제된다.")
+  @Test
+  public void saveAndSend_EmptyRedisKeys() {
+    AlarmEvent testEvent = AlarmEvent.builder()
+        .memberId(hostMember.getId())
+        .reservationId(1L)
+        .facilityName("테스트 시설")
+        .alarmType(AlarmType.NEW_RESERVATION)
+        .build();
+
+    alarmService.saveAndSend(testEvent);
+
+    Set<String> keys = redisTemplate.keys(testEvent.getMemberId() + ":*");
+    assertThat(keys).isEmpty();
+  }
+}

--- a/src/test/java/com/modoospace/alarm/service/AlarmServiceTest.java
+++ b/src/test/java/com/modoospace/alarm/service/AlarmServiceTest.java
@@ -104,7 +104,7 @@ class AlarmServiceTest {
     PageRequest pageRequest = PageRequest.of(0, 10);
     alarmService.searchAlarms("host@email", pageRequest);
 
-    alarmService.delete("host@email", alarm.getId());
+    alarmService.delete(alarm.getId(), "host@email");
 
     String pattern = "searchAlarms::" + hostMember.getEmail() + ":*";
     Set<String> keys = redisTemplate.keys(pattern);

--- a/src/test/java/com/modoospace/alarm/service/AlarmServiceTest.java
+++ b/src/test/java/com/modoospace/alarm/service/AlarmServiceTest.java
@@ -3,18 +3,18 @@ package com.modoospace.alarm.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.modoospace.alarm.controller.dto.AlarmEvent;
-import com.modoospace.alarm.controller.dto.AlarmReadDto;
+import com.modoospace.alarm.domain.AlarmRepository;
 import com.modoospace.alarm.domain.AlarmType;
 import com.modoospace.member.domain.Member;
 import com.modoospace.member.domain.MemberRepository;
 import com.modoospace.member.domain.Role;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
@@ -32,6 +32,9 @@ class AlarmServiceTest {
   private MemberRepository memberRepository;
 
   @Autowired
+  private AlarmRepository alarmRepository;
+
+  @Autowired
   private StringRedisTemplate redisTemplate;
 
   private Member hostMember;
@@ -45,21 +48,50 @@ class AlarmServiceTest {
         .build();
 
     memberRepository.save(hostMember);
+
+    for (int i = 0; i < 10; i++) {
+      AlarmEvent testEvent = AlarmEvent.builder()
+          .memberId(hostMember.getId())
+          .reservationId((long) i)
+          .facilityName("테스트 시설")
+          .alarmType(AlarmType.NEW_RESERVATION)
+          .build();
+      alarmRepository.save(testEvent.toEntity());
+    }
+  }
+
+  @AfterEach
+  public void after() {
+    redisTemplate.getConnectionFactory().getConnection().flushAll();
+  }
+
+  @DisplayName("알람을 검색하면, searchAlarms::멤버ID:페이지넘버를 키값으로 결과가 캐싱된다.")
+  @Test
+  public void searchAlarms_redisSave() {
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    alarmService.searchAlarms("host@email", pageRequest);
+
+    String pattern = "searchAlarms::" + hostMember.getId() + ":*";
+    Set<String> keys = redisTemplate.keys(pattern);
+    assertThat(keys).hasSize(1);
+    System.out.println("keys = " + keys);
   }
 
   @DisplayName("알람을 새로 save하면 redis에 저장되어있던 해당 멤버의 알람 페이징 데이터가 전부 삭제된다.")
   @Test
   public void saveAndSend_EmptyRedisKeys() {
+    PageRequest pageRequest = PageRequest.of(0, 10);
+    alarmService.searchAlarms("host@email", pageRequest);
     AlarmEvent testEvent = AlarmEvent.builder()
         .memberId(hostMember.getId())
         .reservationId(1L)
         .facilityName("테스트 시설")
         .alarmType(AlarmType.NEW_RESERVATION)
         .build();
-
     alarmService.saveAndSend(testEvent);
 
-    Set<String> keys = redisTemplate.keys(testEvent.getMemberId() + ":*");
+    String pattern = "searchAlarms::" + hostMember.getId() + ":*";
+    Set<String> keys = redisTemplate.keys(pattern);
     assertThat(keys).isEmpty();
   }
 }

--- a/src/test/java/com/modoospace/alarm/service/AlarmServiceTest.java
+++ b/src/test/java/com/modoospace/alarm/service/AlarmServiceTest.java
@@ -68,7 +68,7 @@ class AlarmServiceTest {
     redisTemplate.getConnectionFactory().getConnection().flushAll();
   }
 
-  @DisplayName("알람을 검색하면, searchAlarms::멤버ID:페이지넘버를 키값으로 결과가 캐싱된다.")
+  @DisplayName("알람을 검색하면, searchAlarms::이메일:페이지넘버를 키값으로 결과가 캐싱된다.")
   @Test
   public void searchAlarms_redisSave() {
     PageRequest pageRequest = PageRequest.of(0, 10);

--- a/src/test/java/com/modoospace/common/SpELParser/CustomSpELParserTest.java
+++ b/src/test/java/com/modoospace/common/SpELParser/CustomSpELParserTest.java
@@ -126,6 +126,3 @@ public class CustomSpELParserTest {
     }
   }
 }
-
-
-

--- a/src/test/java/com/modoospace/common/SpELParser/CustomSpELParserTest.java
+++ b/src/test/java/com/modoospace/common/SpELParser/CustomSpELParserTest.java
@@ -11,23 +11,25 @@ import org.springframework.expression.spel.SpelEvaluationException;
 
 public class CustomSpELParserTest {
 
-  @DisplayName("#instance.filed 표현식이 주어진 경우 filed의 값을 반환한다.(age)")
+  private Person person = new Person(10L, "jeonghwa", 29, true);
+
+  @DisplayName("#instance.filed 표현식이 주어진 경우 filed의 값을 반환한다.(Long)")
   @Test
-  public void parserTest_InstanceFiled_Age() {
+  public void parserTest_InstanceFiled_Long() {
     String[] parameterNames = {"person"};
-    Object[] args = {new Person("jeonghwa", 29)};
-    String expression = "#person.age";
+    Object[] args = {person};
+    String expression = "#person.id";
 
     Object ret = CustomSpELParser.extractValueFromExpression(parameterNames, args, expression);
 
-    assertThat((Integer) ret).isEqualTo(29);
+    assertThat((Long) ret).isEqualTo(10L);
   }
 
-  @DisplayName("#instance.filed 표현식이 주어진 경우 filed의 값을 반환한다.(name)")
+  @DisplayName("#instance.filed 표현식이 주어진 경우 filed의 값을 반환한다.(String)")
   @Test
-  public void parserTest_InstanceFiled_Name() {
+  public void parserTest_InstanceFiled_String() {
     String[] parameterNames = {"person"};
-    Object[] args = {new Person("jeonghwa", 29)};
+    Object[] args = {person};
     String expression = "#person.name";
 
     Object ret = CustomSpELParser.extractValueFromExpression(parameterNames, args, expression);
@@ -35,12 +37,36 @@ public class CustomSpELParserTest {
     assertThat((String) ret).isEqualTo("jeonghwa");
   }
 
+  @DisplayName("#instance.filed 표현식이 주어진 경우 filed의 값을 반환한다.(Integer)")
+  @Test
+  public void parserTest_InstanceFiled_Integer() {
+    String[] parameterNames = {"person"};
+    Object[] args = {person};
+    String expression = "#person.age";
+
+    Object ret = CustomSpELParser.extractValueFromExpression(parameterNames, args, expression);
+
+    assertThat((Integer) ret).isEqualTo(29);
+  }
+
+  @DisplayName("#instance.filed 표현식이 주어진 경우 filed의 값을 반환한다.(Boolean)")
+  @Test
+  public void parserTest_InstanceFiled_Boolean() {
+    String[] parameterNames = {"person"};
+    Object[] args = {person};
+    String expression = "#person.use";
+
+    Object ret = CustomSpELParser.extractValueFromExpression(parameterNames, args, expression);
+
+    assertThat((Boolean) ret).isEqualTo(true);
+  }
+
 
   @DisplayName("#instance.filed 표현식이 주어진 경우 해당 인스턴스의 없는 field일 경우 Exception이 발생한다.")
   @Test
   public void parserTest_InstanceNotHaveFiled() {
     String[] parameterNames = {"person"};
-    Object[] args = {new Person("jeonghwa", 29)};
+    Object[] args = {person};
     String expression = "#person.noField";
 
     assertThatThrownBy(
@@ -52,7 +78,7 @@ public class CustomSpELParserTest {
   @Test
   public void parserTest_NotAppearParameter_Instance() {
     String[] parameterNames = {"person"};
-    Object[] args = {new Person("jeonghwa", 29)};
+    Object[] args = {person};
     String expression = "#noInstance.age";
 
     assertThatThrownBy(
@@ -81,18 +107,22 @@ public class CustomSpELParserTest {
 
     assertThatThrownBy(
         () -> CustomSpELParser.extractValueFromExpression(parameterNames, args, expression))
-        .isInstanceOf(SpelEvaluationException.class);
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Getter
   public static class Person {
 
+    private Long id;
     private String name;
     private Integer age;
+    private Boolean use;
 
-    public Person(String name, Integer age) {
+    public Person(Long id, String name, Integer age, Boolean use) {
+      this.id = id;
       this.name = name;
       this.age = age;
+      this.use = use;
     }
   }
 }

--- a/src/test/java/com/modoospace/common/SpELParser/CustomSpELParserTest.java
+++ b/src/test/java/com/modoospace/common/SpELParser/CustomSpELParserTest.java
@@ -1,0 +1,100 @@
+package com.modoospace.common.SpELParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import lombok.Getter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.spel.SpelEvaluationException;
+
+public class CustomSpELParserTest {
+
+  @DisplayName("#instance.filed 표현식이 주어진 경우 filed의 값을 반환한다.(age)")
+  @Test
+  public void parserTest_InstanceFiled_Age() {
+    String[] parameterNames = {"person"};
+    Object[] args = {new Person("jeonghwa", 29)};
+    String expression = "#person.age";
+
+    Object ret = CustomSpELParser.extractValueFromExpression(parameterNames, args, expression);
+
+    assertThat((Integer) ret).isEqualTo(29);
+  }
+
+  @DisplayName("#instance.filed 표현식이 주어진 경우 filed의 값을 반환한다.(name)")
+  @Test
+  public void parserTest_InstanceFiled_Name() {
+    String[] parameterNames = {"person"};
+    Object[] args = {new Person("jeonghwa", 29)};
+    String expression = "#person.name";
+
+    Object ret = CustomSpELParser.extractValueFromExpression(parameterNames, args, expression);
+
+    assertThat((String) ret).isEqualTo("jeonghwa");
+  }
+
+
+  @DisplayName("#instance.filed 표현식이 주어진 경우 해당 인스턴스의 없는 field일 경우 Exception이 발생한다.")
+  @Test
+  public void parserTest_InstanceNotHaveFiled() {
+    String[] parameterNames = {"person"};
+    Object[] args = {new Person("jeonghwa", 29)};
+    String expression = "#person.noField";
+
+    assertThatThrownBy(
+        () -> CustomSpELParser.extractValueFromExpression(parameterNames, args, expression))
+        .isInstanceOf(SpelEvaluationException.class);
+  }
+
+  @DisplayName("#instance.filed 표현식이 주어진 경우 해당 인스턴스 파라미터가 아예 존재하지 않는 경우 Exception이 발생한다.")
+  @Test
+  public void parserTest_NotAppearParameter_Instance() {
+    String[] parameterNames = {"person"};
+    Object[] args = {new Person("jeonghwa", 29)};
+    String expression = "#noInstance.age";
+
+    assertThatThrownBy(
+        () -> CustomSpELParser.extractValueFromExpression(parameterNames, args, expression))
+        .isInstanceOf(SpelEvaluationException.class);
+  }
+
+  @DisplayName("#value 표현식이 주어진 경우 value의 값을 반환한다.")
+  @Test
+  public void parserTest_Value() {
+    String[] parameterNames = {"test"};
+    Object[] args = {"test value"};
+    String expression = "#test";
+
+    Object ret = CustomSpELParser.extractValueFromExpression(parameterNames, args, expression);
+
+    assertThat((String) ret).isEqualTo("test value");
+  }
+
+  @DisplayName("#value 표현식이 주어진 경우 해당 value 파라미터가 아예 존재하지 않는 경우 Exception이 발생한다.")
+  @Test
+  public void parserTest_NotAppearParameter_Value() {
+    String[] parameterNames = {"test"};
+    Object[] args = {"test value"};
+    String expression = "#noTest";
+
+    assertThatThrownBy(
+        () -> CustomSpELParser.extractValueFromExpression(parameterNames, args, expression))
+        .isInstanceOf(SpelEvaluationException.class);
+  }
+
+  @Getter
+  public static class Person {
+
+    private String name;
+    private Integer age;
+
+    public Person(String name, Integer age) {
+      this.name = name;
+      this.age = age;
+    }
+  }
+}
+
+
+

--- a/src/test/java/com/modoospace/common/SpELParser/CustomSpELParserTest.java
+++ b/src/test/java/com/modoospace/common/SpELParser/CustomSpELParserTest.java
@@ -3,6 +3,7 @@ package com.modoospace.common.SpELParser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.modoospace.common.CustomSpELParser;
 import lombok.Getter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## 개요
- 알람 조회 결과 `email:pageNum`을 key값으로 Redis에 캐싱하여 DB 접근 횟수를 줄였습니다.
- 알람 삭제기능을 추가하였습니다.

## 작업사항
- Alarm 조회 결과 캐싱

  ```java
  @Cacheable(cacheNames = "searchAlarms", key = "#member.email +':'+ #pageable.pageNumber")
  public Page<AlarmReadDto> searchByMember(Member member, Pageable pageable) {
   ...
  }
  ```

- Alarm 삭제 기능 추가
- Alarm 저장 및 삭제 시, 해당 Member의 Alarm조회 결과 Redis에서 삭제
  - 스프링의 `@CacheEvict`는 하나의 key만 설정해 캐싱 삭제가 가능하며, *(와일드카드)와 같은 Pattern적용이 불가능함
  - 따라서 `@CachePrefixEvict` Annotaion을 생성해 `cacheNames::key:*`패턴의 key값을 가진 데이터 삭제하도록 함
  - 위 과정을 AOP로 수행하였으며 어노테이션에 SpEL 값 전달을 위한 Util클래스(`CustomSpELParser`)를 따로 생성함
  
  ```java
  @Transactional
  @CachePrefixEvict(cacheNames = "searchAlarms", key = "#alarmEvent.email")
  public void saveAndSend(AlarmEvent alarmEvent) {
    Member member = memberService.findMemberByEmail(alarmEvent.getEmail());
    Alarm alarm = alarmRepository.save(alarmEvent.toEntity());
  
    send(alarm.getId(), member.getEmail());
  }
  ```

## 변경로직
- Alarm의 memberId 컬럼을 email로 변경
  > 알람삭제기능 구현 시 로그인한 사람이 누구인지 알기 위해선 session에 저장된 email을 표현계층에서 파라미터로 받을 수 밖에 없는 상황.   
  email을 통해 member를 찾고 내부 메서드 호출을 통해 alarm과 memberId를 넘겨 db와 redis에서 삭제하는 방법으로 가려했으나 AOP는 내부 호출 메서드에 적용이 되지않기때문에 `@CachePrefixEvict`를 사용할 수 없다.   
  ```java
  @Transactional
  public void delete(String loginEmail, Long alarmId) {
    Member loginMember = memberService.findMemberByEmail(loginEmail);
    Alarm alarm = findAlarmById(alarmId);
  
    alarm.verifyManagementPermission(loginMember);
    deleteAlarm(alarm, loginMember.getId());
  }
  
  @CachePrefixEvict(cacheNames = "searchAlarms", key = "#memberId")
  private void deleteAlarm(Alarm alarm, Long memberId){
	  alarmRepository.delete(alarm);
  }
  ```
  > 이를 해결하기 위한 방법들이 존재하긴 하나(자기자신 주입 등), 메서드를 무조건 public하게 만들거나 바이트코드를 조작하는 AspectJ를 사용해야한다.  무조건 내부 호출을 통해서만 사용되야만하는 메서드를 public하게 만드는 것도, 다른 라이브러리를 사용하는것도 좋은방법은 아니라는 생각이 들었다.   
  따라서 아예 alarm의 memberId 컬럼을 email로 변경하고 redis 또한 alarm 저장 key를 `email:pageNum`으로 변경함.   
  어차피 member 조회 시 email로 조회하면 캐시에서 조회하기때문에 성능상 이점도 있고 private한 내부 호출 메서드를 만들 필요도없다.
  ```java
  @Transactional
  @CachePrefixEvict(cacheNames = "searchAlarms", key = "#loginEmail")
  public void delete(Long alarmId, String loginEmail) {
    Member loginMember = memberService.findMemberByEmail(loginEmail);
    Alarm alarm = findAlarmById(alarmId);
  
    alarm.verifyManagementPermission(loginMember);
    alarmRepository.delete(alarm);
  }
  ```
- Alarm 조회 시 Dto로 조회하여 Entity 대신 Dto를 캐싱하도록 변경
