### PR TITLE
[#46] 시설 업데이트, 삭제 쿼리 개선

### DIFF
--- a/src/main/java/com/modoospace/alarm/controller/dto/AlarmEvent.java
+++ b/src/main/java/com/modoospace/alarm/controller/dto/AlarmEvent.java
@@ -36,7 +36,7 @@ public class AlarmEvent {
         return AlarmEvent.builder()
             .email(reservation.getHost().getEmail())
             .reservationId(reservation.getId())
-            .facilityName(reservation.getFacility().getName())
+            .facilityName(reservation.getFacility().getFacilityName())
             .alarmType(AlarmType.NEW_RESERVATION)
             .build();
     }
@@ -45,7 +45,7 @@ public class AlarmEvent {
         return AlarmEvent.builder()
             .email(reservation.getVisitor().getEmail())
             .reservationId(reservation.getId())
-            .facilityName(reservation.getFacility().getName())
+            .facilityName(reservation.getFacility().getFacilityName())
             .alarmType(AlarmType.APPROVED_RESERVATION)
             .build();
     }
@@ -54,7 +54,7 @@ public class AlarmEvent {
         return AlarmEvent.builder()
             .email(reservation.getHost().getEmail())
             .reservationId(reservation.getId())
-            .facilityName(reservation.getFacility().getName())
+            .facilityName(reservation.getFacility().getFacilityName())
             .alarmType(AlarmType.CANCELED_RESERVATION)
             .build();
     }

--- a/src/main/java/com/modoospace/config/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/modoospace/config/auth/CustomOAuth2UserService.java
@@ -58,8 +58,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         .map(entity -> entity.updateNameFromProvider(attributes.getName()))
         .orElse(attributes.toEntity());
 
-    memberCacheRepository.save(member);
     memberRepository.save(member);
+    memberCacheRepository.save(member);
     return member;
   }
 }

--- a/src/main/java/com/modoospace/space/controller/FacilityController.java
+++ b/src/main/java/com/modoospace/space/controller/FacilityController.java
@@ -5,6 +5,7 @@ import com.modoospace.space.controller.dto.facility.FacilityCreateRequest;
 import com.modoospace.space.controller.dto.facility.FacilityDetailResponse;
 import com.modoospace.space.controller.dto.facility.FacilityResponse;
 import com.modoospace.space.controller.dto.facility.FacilitySearchRequest;
+import com.modoospace.space.controller.dto.facility.FacilitySettingUpdateRequest;
 import com.modoospace.space.controller.dto.facility.FacilityUpdateRequest;
 import com.modoospace.space.sevice.FacilityService;
 import java.net.URI;
@@ -27,43 +28,51 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/spaces/{spaceId}/facilities")
 public class FacilityController {
 
-  private final FacilityService facilityService;
+    private final FacilityService facilityService;
 
-  @PostMapping()
-  public ResponseEntity<Void> create(@PathVariable Long spaceId,
-      @RequestBody @Valid FacilityCreateRequest createRequest,
-      @LoginEmail String loginEmail) {
-    Long facilityId = facilityService.createFacility(spaceId, createRequest, loginEmail);
-    return ResponseEntity
-        .created(URI.create("/api/v1/spaces/" + spaceId + "/facilities/" + facilityId)).build();
-  }
+    @PostMapping()
+    public ResponseEntity<Void> create(@PathVariable Long spaceId,
+        @RequestBody @Valid FacilityCreateRequest createRequest,
+        @LoginEmail String loginEmail) {
+        Long facilityId = facilityService.createFacility(spaceId, createRequest, loginEmail);
+        return ResponseEntity
+            .created(URI.create("/api/v1/spaces/" + spaceId + "/facilities/" + facilityId)).build();
+    }
 
-  @GetMapping()
-  public ResponseEntity<Page<FacilityResponse>> search(@PathVariable Long spaceId,
-      FacilitySearchRequest searchDto, Pageable pageable) {
-    Page<FacilityResponse> facilityReadDtos = facilityService
-        .searchFacility(spaceId, searchDto, pageable);
-    return ResponseEntity.ok().body(facilityReadDtos);
-  }
+    @GetMapping()
+    public ResponseEntity<Page<FacilityResponse>> search(@PathVariable Long spaceId,
+        FacilitySearchRequest searchDto, Pageable pageable) {
+        Page<FacilityResponse> facilityReadDtos = facilityService
+            .searchFacility(spaceId, searchDto, pageable);
+        return ResponseEntity.ok().body(facilityReadDtos);
+    }
 
-  @GetMapping("/{facilityId}")
-  public ResponseEntity<FacilityDetailResponse> find(@PathVariable Long facilityId) {
-    FacilityDetailResponse facilityReadDto = facilityService.findFacility(facilityId);
-    return ResponseEntity.ok().body(facilityReadDto);
-  }
+    @GetMapping("/{facilityId}")
+    public ResponseEntity<FacilityDetailResponse> find(@PathVariable Long facilityId) {
+        FacilityDetailResponse facilityReadDto = facilityService.findFacility(facilityId);
+        return ResponseEntity.ok().body(facilityReadDto);
+    }
 
-  @PutMapping("/{facilityId}")
-  public ResponseEntity<Void> update(@PathVariable Long facilityId,
-      @RequestBody @Valid FacilityUpdateRequest updateRequest,
-      @LoginEmail String loginEmail) {
-    facilityService.updateFacility(facilityId, updateRequest, loginEmail);
-    return ResponseEntity.noContent().build();
-  }
+    @PutMapping("/{facilityId}")
+    public ResponseEntity<Void> update(@PathVariable Long facilityId,
+        @RequestBody @Valid FacilityUpdateRequest updateRequest,
+        @LoginEmail String loginEmail) {
+        facilityService.updateFacility(facilityId, updateRequest, loginEmail);
+        return ResponseEntity.noContent().build();
+    }
 
-  @DeleteMapping("/{facilityId}")
-  public ResponseEntity<Void> delete(@PathVariable Long facilityId,
-      @LoginEmail String loginEmail) {
-    facilityService.deleteFacility(facilityId, loginEmail);
-    return ResponseEntity.noContent().build();
-  }
+    @PutMapping("/{facilityId}/setting")
+    public ResponseEntity<Void> updateSetting(@PathVariable Long facilityId,
+        @RequestBody @Valid FacilitySettingUpdateRequest updateRequest,
+        @LoginEmail String loginEmail) {
+        facilityService.updateFacilitySetting(facilityId, updateRequest, loginEmail);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{facilityId}")
+    public ResponseEntity<Void> delete(@PathVariable Long facilityId,
+        @LoginEmail String loginEmail) {
+        facilityService.deleteFacility(facilityId, loginEmail);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/modoospace/space/controller/dto/facility/FacilityCreateRequest.java
+++ b/src/main/java/com/modoospace/space/controller/dto/facility/FacilityCreateRequest.java
@@ -38,7 +38,7 @@ public class FacilityCreateRequest {
     private String description;
 
     @Builder.Default
-    private List<TimeSettingCreateRequest> timeSettings = Arrays.asList(new TimeSettingCreateRequest());
+    private List<TimeSettingCreateRequest> timeSettings = List.of(new TimeSettingCreateRequest());
 
     @Builder.Default
     private List<WeekdaySettingCreateRequest> weekdaySettings = Arrays.asList(
@@ -80,13 +80,13 @@ public class FacilityCreateRequest {
 
     private List<TimeSetting> toTimeSettings(List<TimeSettingCreateRequest> timeSettings) {
         return timeSettings.stream()
-            .map(settingcreateRequest -> settingcreateRequest.toEntity())
+            .map(TimeSettingCreateRequest::toEntity)
             .collect(Collectors.toList());
     }
 
     private List<WeekdaySetting> toWeekdaySettings(List<WeekdaySettingCreateRequest> weekdaySettings) {
         return weekdaySettings.stream()
-            .map(settingcreateRequest -> settingcreateRequest.toEntity())
+            .map(WeekdaySettingCreateRequest::toEntity)
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/modoospace/space/controller/dto/facility/FacilitySettingUpdateRequest.java
+++ b/src/main/java/com/modoospace/space/controller/dto/facility/FacilitySettingUpdateRequest.java
@@ -1,0 +1,40 @@
+package com.modoospace.space.controller.dto.facility;
+
+import com.modoospace.space.controller.dto.timeSetting.TimeSettingCreateRequest;
+import com.modoospace.space.controller.dto.weekdaySetting.WeekdaySettingCreateRequest;
+import com.modoospace.space.domain.TimeSetting;
+import com.modoospace.space.domain.TimeSettings;
+import com.modoospace.space.domain.WeekdaySetting;
+import com.modoospace.space.domain.WeekdaySettings;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.validation.constraints.NotEmpty;
+
+public class FacilitySettingUpdateRequest {
+
+    @NotEmpty
+    private final List<TimeSettingCreateRequest> timeSettings;
+
+    @NotEmpty
+    private final List<WeekdaySettingCreateRequest> weekdaySettings;
+
+    public FacilitySettingUpdateRequest(List<TimeSettingCreateRequest> timeSettings,
+        List<WeekdaySettingCreateRequest> weekdaySettings) {
+        this.timeSettings = timeSettings;
+        this.weekdaySettings = weekdaySettings;
+    }
+
+    public TimeSettings toTimeSettings() {
+        List<TimeSetting> entities = this.timeSettings.stream()
+            .map(TimeSettingCreateRequest::toEntity)
+            .collect(Collectors.toList());
+        return new TimeSettings(entities);
+    }
+
+    public WeekdaySettings toWeekdaySettings() {
+        List<WeekdaySetting> entities = this.weekdaySettings.stream()
+            .map(WeekdaySettingCreateRequest::toEntity)
+            .collect(Collectors.toList());
+        return new WeekdaySettings(entities);
+    }
+}

--- a/src/main/java/com/modoospace/space/controller/dto/facility/FacilityUpdateRequest.java
+++ b/src/main/java/com/modoospace/space/controller/dto/facility/FacilityUpdateRequest.java
@@ -1,15 +1,6 @@
 package com.modoospace.space.controller.dto.facility;
 
-import com.modoospace.space.controller.dto.timeSetting.TimeSettingCreateRequest;
-import com.modoospace.space.controller.dto.weekdaySetting.WeekdaySettingCreateRequest;
 import com.modoospace.space.domain.Facility;
-import com.modoospace.space.domain.TimeSetting;
-import com.modoospace.space.domain.TimeSettings;
-import com.modoospace.space.domain.WeekdaySetting;
-import com.modoospace.space.domain.WeekdaySettings;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
@@ -18,7 +9,6 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@Builder
 public class FacilityUpdateRequest {
 
     @NotEmpty
@@ -35,24 +25,14 @@ public class FacilityUpdateRequest {
 
     private String description;
 
-    @Builder.Default
-    private List<TimeSettingCreateRequest> timeSettings = new ArrayList<>();
-
-    @Builder.Default
-    private List<WeekdaySettingCreateRequest> weekdaySettings = new ArrayList<>();
-
-    public FacilityUpdateRequest(String name, Boolean reservationEnable,
-        Integer minUser, Integer maxUser, String description,
-        List<TimeSettingCreateRequest> timeSettings, List<WeekdaySettingCreateRequest> weekdaySettings) {
+    @Builder
+    public FacilityUpdateRequest(String name, Boolean reservationEnable, Integer minUser,
+        Integer maxUser, String description) {
         this.name = name;
         this.reservationEnable = reservationEnable;
-
         this.minUser = minUser;
         this.maxUser = maxUser;
         this.description = description;
-
-        this.timeSettings = timeSettings;
-        this.weekdaySettings = weekdaySettings;
     }
 
     public Facility toEntity() {
@@ -62,20 +42,6 @@ public class FacilityUpdateRequest {
             .minUser(minUser)
             .maxUser(maxUser)
             .description(description)
-            .timeSettings(new TimeSettings(toTimeSettings(timeSettings)))
-            .weekdaySettings(new WeekdaySettings(toWeekdaySettings(weekdaySettings)))
             .build();
-    }
-
-    private List<TimeSetting> toTimeSettings(List<TimeSettingCreateRequest> timeSettings) {
-        return timeSettings.stream()
-            .map(settingcreateRequest -> settingcreateRequest.toEntity())
-            .collect(Collectors.toList());
-    }
-
-    private List<WeekdaySetting> toWeekdaySettings(List<WeekdaySettingCreateRequest> weekdaySettings) {
-        return weekdaySettings.stream()
-            .map(settingcreateRequest -> settingcreateRequest.toEntity())
-            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/modoospace/space/domain/Facility.java
+++ b/src/main/java/com/modoospace/space/domain/Facility.java
@@ -106,24 +106,22 @@ public class Facility extends BaseTimeEntity {
         return minUser <= maxUser;
     }
 
-    public void update(Facility facility, Member loginMember) {
-        verifyManagementPermission(loginMember);
-
+    public void update(Facility facility) {
         this.name = facility.getName();
         this.reservationEnable = facility.getReservationEnable();
         this.minUser = facility.getMinUser();
         this.maxUser = facility.getMaxUser();
         this.description = facility.getDescription();
 
-        if (!facility.getTimeSettings().isEmpty()) {
+        if (facility.shouldUpdateTimeSettings()) {
             this.timeSettings.update(facility.getTimeSettings(), this);
         }
 
-        if (!facility.getWeekdaySettings().isEmpty()) {
+        if (facility.shouldUpdateWeekdaySettings()) {
             this.weekdaySettings.update(facility.getWeekdaySettings(), this);
         }
 
-        if (!facility.getTimeSettings().isEmpty() || !facility.getWeekdaySettings().isEmpty()) {
+        if (facility.shouldCreateSchedules()) {
             Schedules schedules = Schedules
                 .create3MonthFacilitySchedules(this.timeSettings, this.weekdaySettings,
                     YearMonth.now());
@@ -131,22 +129,29 @@ public class Facility extends BaseTimeEntity {
         }
     }
 
-    public void create1MonthDefaultSchedules(YearMonth createYearMonth,
-        Member loginMember) {
-        verifyManagementPermission(loginMember);
+    private boolean shouldUpdateTimeSettings() {
+        return !timeSettings.isEmpty();
+    }
 
+    private boolean shouldUpdateWeekdaySettings() {
+        return !weekdaySettings.isEmpty();
+    }
+
+    public boolean shouldCreateSchedules() {
+        return shouldUpdateTimeSettings() || shouldUpdateWeekdaySettings();
+    }
+
+    public void create1MonthDefaultSchedules(YearMonth createYearMonth) {
         Schedules schedules = Schedules.create1MonthFacilitySchedules(
             this.timeSettings, this.weekdaySettings, createYearMonth);
         this.schedules.addAll(schedules, this);
     }
 
-    public void addSchedule(Schedule createSchedule, Member loginMember) {
-        verifyManagementPermission(loginMember);
+    public void addSchedule(Schedule createSchedule) {
         schedules.addSchedule(createSchedule);
     }
 
-    public void updateSchedule(Schedule updateSchedule, Schedule schedule, Member loginMember) {
-        verifyManagementPermission(loginMember);
+    public void updateSchedule(Schedule updateSchedule, Schedule schedule) {
         schedules.updateSchedule(updateSchedule, schedule);
     }
 

--- a/src/main/java/com/modoospace/space/domain/Facility.java
+++ b/src/main/java/com/modoospace/space/domain/Facility.java
@@ -170,4 +170,8 @@ public class Facility extends BaseTimeEntity {
             throw new LimitNumOfUserException();
         }
     }
+
+    public String getName() {
+        return space.getName() + "(" + name + ")";
+    }
 }

--- a/src/main/java/com/modoospace/space/domain/Facility.java
+++ b/src/main/java/com/modoospace/space/domain/Facility.java
@@ -123,6 +123,7 @@ public class Facility extends BaseTimeEntity {
     }
 
     public void add1MonthDefaultSchedules(YearMonth yearMonth) {
+        schedules.delete1Month(yearMonth);
         schedules.add1Month(timeSettings, weekdaySettings, yearMonth);
     }
 

--- a/src/main/java/com/modoospace/space/domain/Facility.java
+++ b/src/main/java/com/modoospace/space/domain/Facility.java
@@ -171,7 +171,7 @@ public class Facility extends BaseTimeEntity {
         }
     }
 
-    public String getName() {
+    public String getFacilityName() {
         return space.getName() + "(" + name + ")";
     }
 }

--- a/src/main/java/com/modoospace/space/domain/Schedule.java
+++ b/src/main/java/com/modoospace/space/domain/Schedule.java
@@ -3,6 +3,7 @@ package com.modoospace.space.domain;
 import com.modoospace.common.exception.ConflictingTimeException;
 import com.sun.istack.NotNull;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -75,6 +76,10 @@ public class Schedule {
 
     public void setFacility(Facility facility) {
         this.facility = facility;
+    }
+
+    public boolean isYearMonthEqual(YearMonth yearMonth) {
+        return YearMonth.of(date.getYear(), date.getMonth()).equals(yearMonth);
     }
 
     private boolean isDateEqual(Schedule targetSchedule) {

--- a/src/main/java/com/modoospace/space/domain/ScheduleRepository.java
+++ b/src/main/java/com/modoospace/space/domain/ScheduleRepository.java
@@ -1,7 +1,6 @@
 package com.modoospace.space.domain;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/modoospace/space/domain/Schedules.java
+++ b/src/main/java/com/modoospace/space/domain/Schedules.java
@@ -5,6 +5,7 @@ import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
@@ -111,6 +112,13 @@ public class Schedules {
         Schedules createSchedules = Schedules.create1MonthSchedules(
             timeSettings, weekdaySettings, yearMonth);
         this.schedules.addAll(createSchedules.getSchedules());
+    }
+
+    public void delete1Month(YearMonth yearMonth) {
+        List<Schedule> deleteSchedules = this.schedules.stream()
+            .filter(schedule -> schedule.isYearMonthEqual(yearMonth))
+            .collect(Collectors.toList());
+        this.schedules.removeAll(deleteSchedules);
     }
 
     @Override

--- a/src/main/java/com/modoospace/space/domain/Space.java
+++ b/src/main/java/com/modoospace/space/domain/Space.java
@@ -69,8 +69,7 @@ public class Space extends BaseTimeEntity {
         this.facilities = facilities;
     }
 
-    public void update(final Space updateSpace, Member loginMember) {
-        verifyManagementPermission(loginMember);
+    public void update(final Space updateSpace) {
         this.name = updateSpace.getName();
         this.description = updateSpace.getDescription();
         this.address = updateSpace.getAddress();

--- a/src/main/java/com/modoospace/space/domain/TimeSettings.java
+++ b/src/main/java/com/modoospace/space/domain/TimeSettings.java
@@ -2,7 +2,6 @@ package com.modoospace.space.domain;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,7 +27,7 @@ public class TimeSettings {
     }
 
     private List<TimeSetting> validateAndMerge(List<TimeSetting> timeSettings) {
-        Collections.sort(timeSettings, Comparator.comparing(TimeSetting::getStartHour));
+        timeSettings.sort(Comparator.comparing(TimeSetting::getStartHour));
 
         while (validateAndMergeContinuousTime(timeSettings)) {
         }
@@ -63,13 +62,9 @@ public class TimeSettings {
             .collect(Collectors.toList());
     }
 
-    public boolean isEmpty() {
-        return timeSettings.isEmpty();
-    }
-
     public void update(TimeSettings timeSettings, Facility facility) {
         this.timeSettings.clear();
-        this.timeSettings.addAll(timeSettings.getTimeSettings());
         timeSettings.setFacility(facility);
+        this.timeSettings.addAll(timeSettings.getTimeSettings());
     }
 }

--- a/src/main/java/com/modoospace/space/domain/WeekdaySettings.java
+++ b/src/main/java/com/modoospace/space/domain/WeekdaySettings.java
@@ -2,7 +2,6 @@ package com.modoospace.space.domain;
 
 import java.time.DayOfWeek;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import javax.persistence.CascadeType;
@@ -18,42 +17,38 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WeekdaySettings {
 
-  @OneToMany(mappedBy = "facility", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-  private List<WeekdaySetting> weekdaySettings = new ArrayList<>();
+    @OneToMany(mappedBy = "facility", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<WeekdaySetting> weekdaySettings = new ArrayList<>();
 
-  public WeekdaySettings(List<WeekdaySetting> weekdaySettings) {
-    validateWeekdaySettings(weekdaySettings);
-    this.weekdaySettings = weekdaySettings;
-  }
-
-  private void validateWeekdaySettings(List<WeekdaySetting> weekdaySettings) {
-    Collections.sort(weekdaySettings, Comparator.comparing(WeekdaySetting::getWeekday));
-
-    for (int i = 0; i < weekdaySettings.size() - 1; i++) {
-      WeekdaySetting weekdaySetting = weekdaySettings.get(i);
-      WeekdaySetting compareWeekdaySetting = weekdaySettings.get(i + 1);
-      weekdaySetting.verifyDuplicated(compareWeekdaySetting);
+    public WeekdaySettings(List<WeekdaySetting> weekdaySettings) {
+        validateWeekdaySettings(weekdaySettings);
+        this.weekdaySettings = weekdaySettings;
     }
-  }
 
-  public void setFacility(Facility facility) {
-    for (WeekdaySetting weekdaySetting : weekdaySettings) {
-      weekdaySetting.setFacility(facility);
+    private void validateWeekdaySettings(List<WeekdaySetting> weekdaySettings) {
+        weekdaySettings.sort(Comparator.comparing(WeekdaySetting::getWeekday));
+
+        for (int i = 0; i < weekdaySettings.size() - 1; i++) {
+            WeekdaySetting weekdaySetting1 = weekdaySettings.get(i);
+            WeekdaySetting weekdaySetting2 = weekdaySettings.get(i + 1);
+            weekdaySetting1.verifyDuplicated(weekdaySetting2);
+        }
     }
-  }
 
-  public boolean isContainWeekday(DayOfWeek dayOfWeek) {
-    return weekdaySettings.stream()
-        .anyMatch(weekdaySetting -> weekdaySetting.isEqualWeekday(dayOfWeek));
-  }
+    public void setFacility(Facility facility) {
+        for (WeekdaySetting weekdaySetting : weekdaySettings) {
+            weekdaySetting.setFacility(facility);
+        }
+    }
 
-  public boolean isEmpty() {
-    return weekdaySettings.isEmpty();
-  }
+    public boolean isContainWeekday(DayOfWeek dayOfWeek) {
+        return weekdaySettings.stream()
+            .anyMatch(weekdaySetting -> weekdaySetting.isEqualWeekday(dayOfWeek));
+    }
 
-  public void update(WeekdaySettings weekdaySettings, Facility facility) {
-    this.weekdaySettings.clear();
-    this.weekdaySettings.addAll(weekdaySettings.getWeekdaySettings());
-    weekdaySettings.setFacility(facility);
-  }
+    public void update(WeekdaySettings weekdaySettings, Facility facility) {
+        this.weekdaySettings.clear();
+        weekdaySettings.setFacility(facility);
+        this.weekdaySettings.addAll(weekdaySettings.getWeekdaySettings());
+    }
 }

--- a/src/main/java/com/modoospace/space/repository/ScheduleQueryRepository.java
+++ b/src/main/java/com/modoospace/space/repository/ScheduleQueryRepository.java
@@ -107,7 +107,7 @@ public class ScheduleQueryRepository {
             .execute();
     }
 
-    public void deleteSchedules(Facility facility) {
+    public void deleteFacilitySchedules(Facility facility) {
         jpaQueryFactory
             .delete(schedule)
             .where(facilityEq(facility))

--- a/src/main/java/com/modoospace/space/repository/ScheduleQueryRepository.java
+++ b/src/main/java/com/modoospace/space/repository/ScheduleQueryRepository.java
@@ -107,6 +107,13 @@ public class ScheduleQueryRepository {
             .execute();
     }
 
+    public void deleteSchedules(Facility facility) {
+        jpaQueryFactory
+            .delete(schedule)
+            .where(facilityEq(facility))
+            .execute();
+    }
+
     private BooleanExpression facilityEq(Facility facility) {
         return facility != null ? schedule.facility.eq(facility) : null;
     }

--- a/src/main/java/com/modoospace/space/sevice/FacilityService.java
+++ b/src/main/java/com/modoospace/space/sevice/FacilityService.java
@@ -7,6 +7,7 @@ import com.modoospace.space.controller.dto.facility.FacilityCreateRequest;
 import com.modoospace.space.controller.dto.facility.FacilityDetailResponse;
 import com.modoospace.space.controller.dto.facility.FacilityResponse;
 import com.modoospace.space.controller.dto.facility.FacilitySearchRequest;
+import com.modoospace.space.controller.dto.facility.FacilitySettingUpdateRequest;
 import com.modoospace.space.controller.dto.facility.FacilityUpdateRequest;
 import com.modoospace.space.domain.Facility;
 import com.modoospace.space.domain.FacilityRepository;
@@ -62,10 +63,18 @@ public class FacilityService {
         facility.verifyManagementPermission(loginMember);
 
         Facility updatedFacility = updateRequest.toEntity();
-        if (updatedFacility.shouldCreateSchedules()) { // TODO : 성능 비교 필요.
-            scheduleQueryRepository.deleteSchedules(facility);
-        }
         facility.update(updatedFacility);
+    }
+
+    @Transactional
+    public void updateFacilitySetting(Long facilityId, FacilitySettingUpdateRequest updateRequest,
+        String loginEmail) {
+        Member loginMember = memberService.findMemberByEmail(loginEmail);
+        Facility facility = findFacilityById(facilityId);
+        facility.verifyManagementPermission(loginMember);
+
+        scheduleQueryRepository.deleteFacilitySchedules(facility);
+        facility.updateSetting(updateRequest.toTimeSettings(), updateRequest.toWeekdaySettings());
     }
 
     @Transactional
@@ -74,6 +83,7 @@ public class FacilityService {
         Facility facility = findFacilityById(facilityId);
         facility.verifyManagementPermission(loginMember);
 
+        scheduleQueryRepository.deleteFacilitySchedules(facility);
         facilityRepository.delete(facility);
     }
 

--- a/src/main/java/com/modoospace/space/sevice/ScheduleService.java
+++ b/src/main/java/com/modoospace/space/sevice/ScheduleService.java
@@ -34,8 +34,9 @@ public class ScheduleService {
         String loginEmail) {
         Member loginMember = memberService.findMemberByEmail(loginEmail);
         Facility facility = findFacilityById(facilityId);
+        facility.verifyManagementPermission(loginMember);
 
-        facility.addSchedule(createRequest.toEntity(facility), loginMember);
+        facility.addSchedule(createRequest.toEntity(facility));
     }
 
     public ScheduleResponse findSchedule(Long facilityScheduleId) {
@@ -50,8 +51,9 @@ public class ScheduleService {
         Member loginMember = memberService.findMemberByEmail(loginEmail);
         Schedule schedule = findScheduleById(facilityScheduleId);
         Facility facility = schedule.getFacility();
+        facility.verifyManagementPermission(loginMember);
 
-        facility.updateSchedule(updateRequest.toEntity(facility), schedule, loginMember);
+        facility.updateSchedule(updateRequest.toEntity(facility), schedule);
     }
 
     @Transactional
@@ -80,14 +82,15 @@ public class ScheduleService {
         String loginEmail) {
         Member loginMember = memberService.findMemberByEmail(loginEmail);
         Facility facility = findFacilityById(facilityId);
+        facility.verifyManagementPermission(loginMember);
 
         // 문제 : 쿼리를 직접날려 삭제를 실행했기때문에, 영속성컨테이너의 facility의 스케줄데이터는 그대로.
-        delete1MonthSchedules(facility, createYearMonth, loginMember);
+        scheduleQueryRepository.delete1MonthSchedules(facility, createYearMonth);
         // 해결 : 영속성 컨텍스트를 비운 후 엔티티를 다시 조회하여 데이터 일관성을 보장.
         // 다른방식 : 엔티티의 데이터를 코드로 직접 삭제해줘도 된다.
         em.clear();
         facility = findFacilityById(facilityId);
-        facility.create1MonthDefaultSchedules(createYearMonth, loginMember);
+        facility.create1MonthDefaultSchedules(createYearMonth);
     }
 
 
@@ -107,12 +110,6 @@ public class ScheduleService {
         String loginEmail) {
         Member loginMember = memberService.findMemberByEmail(loginEmail);
         Facility facility = findFacilityById(facilityId);
-
-        delete1MonthSchedules(facility, deleteYearMonth, loginMember);
-    }
-
-    private void delete1MonthSchedules(Facility facility, YearMonth deleteYearMonth,
-        Member loginMember) {
         facility.verifyManagementPermission(loginMember);
 
         scheduleQueryRepository.delete1MonthSchedules(facility, deleteYearMonth);

--- a/src/main/java/com/modoospace/space/sevice/SpaceService.java
+++ b/src/main/java/com/modoospace/space/sevice/SpaceService.java
@@ -55,17 +55,18 @@ public class SpaceService {
         String loginEmail) {
         Member loginMember = memberService.findMemberByEmail(loginEmail);
         Space space = findSpaceById(spaceId);
-        Space updatedSpace = updateRequest.toEntity(space.getCategory(), space.getHost());
+        space.verifyManagementPermission(loginMember);
 
-        space.update(updatedSpace, loginMember);
+        Space updatedSpace = updateRequest.toEntity(space.getCategory(), space.getHost());
+        space.update(updatedSpace);
     }
 
     @Transactional
     public void deleteSpace(Long spaceId, String loginEmail) {
         Member loginMember = memberService.findMemberByEmail(loginEmail);
         Space space = findSpaceById(spaceId);
-
         space.verifyDeletePermission(loginMember);
+
         spaceRepository.delete(space);
     }
 

--- a/src/test/java/com/modoospace/space/domain/FacilityTest.java
+++ b/src/test/java/com/modoospace/space/domain/FacilityTest.java
@@ -102,7 +102,7 @@ class FacilityTest {
 
     @DisplayName("공간이름 + 시설이름을 반환한다.")
     @Test
-    public void getName() {
+    public void getFacilityName() {
         Facility facility = Facility.builder()
             .name("4인실")
             .minUser(2)
@@ -113,6 +113,6 @@ class FacilityTest {
             .space(space)
             .build();
 
-        assertThat(facility.getName()).isEqualTo("슈가맨워크(4인실)");
+        assertThat(facility.getFacilityName()).isEqualTo("슈가맨워크(4인실)");
     }
 }

--- a/src/test/java/com/modoospace/space/domain/FacilityTest.java
+++ b/src/test/java/com/modoospace/space/domain/FacilityTest.java
@@ -1,32 +1,118 @@
 package com.modoospace.space.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.modoospace.common.exception.LimitNumOfUserException;
+import com.modoospace.common.exception.NotOpenedFacilityException;
+import com.modoospace.member.domain.Member;
+import com.modoospace.member.domain.Role;
 import java.time.DayOfWeek;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class FacilityTest {
 
+    private Space space;
+    private List<TimeSetting> timeSettings;
+
+    List<WeekdaySetting> weekdaySettings;
+
+    @BeforeEach
+    public void before() {
+        Member member = Member.builder()
+            .id(1L)
+            .email("host@email")
+            .name("host")
+            .role(Role.HOST)
+            .build();
+
+        space = Space.builder()
+            .name("슈가맨워크")
+            .host(member)
+            .build();
+
+        timeSettings = Arrays.asList(
+            new TimeSetting(new TimeRange(9, 12)), new TimeSetting(new TimeRange(14, 20)));
+
+        weekdaySettings = Arrays.asList(
+            new WeekdaySetting(DayOfWeek.WEDNESDAY), new WeekdaySetting(DayOfWeek.THURSDAY),
+            new WeekdaySetting(DayOfWeek.FRIDAY), new WeekdaySetting(DayOfWeek.SATURDAY));
+    }
+
     @DisplayName("시설 생성 시 TimeSetting과 WeekSetting에 맞춰 오늘 날짜로 부터 3개월간의 스케줄데이터를 생성한다.")
     @Test
     public void createFacility_24HourOpen_ifNotSelectSetting() {
-
-        List<TimeSetting> timeSettings = Arrays.asList(
-            new TimeSetting(new TimeRange(9, 12)), new TimeSetting(new TimeRange(14, 20)));
-
-        List<WeekdaySetting> weekdaySettings = Arrays.asList(
-            new WeekdaySetting(DayOfWeek.WEDNESDAY), new WeekdaySetting(DayOfWeek.THURSDAY),
-            new WeekdaySetting(DayOfWeek.FRIDAY), new WeekdaySetting(DayOfWeek.SATURDAY));
-
         Facility facility = Facility.builder()
-            .name("테스트")
-            .minUser(1)
-            .maxUser(3)
+            .name("4인실")
+            .minUser(2)
+            .maxUser(4)
+            .reservationEnable(true)
             .timeSettings(new TimeSettings(timeSettings))
             .weekdaySettings(new WeekdaySettings(weekdaySettings))
+            .space(space)
             .build();
 
         System.out.println(facility.getSchedules());
+    }
+
+    @DisplayName("예약이 불가능한 상태일 경우 예외를 던진다.")
+    @Test
+    public void verifyReservationEnable_throwException_ifNotEnable() {
+        Facility facility = Facility.builder()
+            .name("4인실")
+            .minUser(2)
+            .maxUser(4)
+            .reservationEnable(false)
+            .timeSettings(new TimeSettings(timeSettings))
+            .weekdaySettings(new WeekdaySettings(weekdaySettings))
+            .space(space)
+            .build();
+
+        assertAll(
+            () -> assertThatThrownBy(facility::verifyReservationEnable).isInstanceOf(
+                NotOpenedFacilityException.class)
+        );
+    }
+
+    @DisplayName("사용인원이 제한된 수보다 적거나 크면 예외를 던진다.")
+    @Test
+    public void verityNumOfUser_throwException_ifBigOrSmallUserNum() {
+        Facility facility = Facility.builder()
+            .name("4인실")
+            .minUser(2)
+            .maxUser(4)
+            .reservationEnable(false)
+            .timeSettings(new TimeSettings(timeSettings))
+            .weekdaySettings(new WeekdaySettings(weekdaySettings))
+            .space(space)
+            .build();
+
+        assertAll(
+            () -> assertThatThrownBy(() -> facility.verityNumOfUser(1)).isInstanceOf(
+                LimitNumOfUserException.class),
+            () -> assertThatThrownBy(() -> facility.verityNumOfUser(5)).isInstanceOf(
+                LimitNumOfUserException.class)
+        );
+    }
+
+    @DisplayName("공간이름 + 시설이름을 반환한다.")
+    @Test
+    public void getName() {
+        Facility facility = Facility.builder()
+            .name("4인실")
+            .minUser(2)
+            .maxUser(4)
+            .reservationEnable(false)
+            .timeSettings(new TimeSettings(timeSettings))
+            .weekdaySettings(new WeekdaySettings(weekdaySettings))
+            .space(space)
+            .build();
+
+        assertThat(facility.getName()).isEqualTo("슈가맨워크(4인실)");
     }
 }

--- a/src/test/java/com/modoospace/space/domain/SchedulesTest.java
+++ b/src/test/java/com/modoospace/space/domain/SchedulesTest.java
@@ -22,7 +22,7 @@ class SchedulesTest {
         WeekdaySettings weekDaySetting = createWeekDaySetting(DayOfWeek.MONDAY, DayOfWeek.TUESDAY,
             DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY);
         Schedules schedules = Schedules
-            .create3MonthFacilitySchedules(timeSettings, weekDaySetting, YearMonth.now());
+            .create3MonthSchedules(timeSettings, weekDaySetting, YearMonth.now());
 
         System.out.println(schedules);
     }
@@ -47,7 +47,7 @@ class SchedulesTest {
         Schedules schedules = createSchedules(createNowDateSchedule(9, 12));
         Schedule addSchedule = createNowDateSchedule(13, 14);
 
-        schedules.addSchedule(addSchedule);
+        schedules.add(addSchedule);
 
         Schedule retSchedule = schedules.getSchedules().get(1);
         assertAll(
@@ -62,7 +62,7 @@ class SchedulesTest {
         Schedules schedules = createSchedules(createNowDateSchedule(9, 12));
         Schedule addSchedule = createNowDateSchedule(12, 14);
 
-        schedules.addSchedule(addSchedule);
+        schedules.add(addSchedule);
 
         Schedule retSchedule = schedules.getSchedules().get(0);
         assertAll(
@@ -78,7 +78,7 @@ class SchedulesTest {
             createNowDateSchedule(13, 18));
         Schedule addSchedule = createNowDateSchedule(12, 13);
 
-        schedules.addSchedule(addSchedule);
+        schedules.add(addSchedule);
 
         Schedule retSchedule = schedules.getSchedules().get(0);
         assertAll(
@@ -93,7 +93,7 @@ class SchedulesTest {
         Schedules schedules = createSchedules(createNowDateSchedule(9, 12));
         Schedule addSchedule = createNowDateSchedule(11, 13);
 
-        assertThatThrownBy(() -> schedules.addSchedule(addSchedule))
+        assertThatThrownBy(() -> schedules.add(addSchedule))
             .isInstanceOf(ConflictingTimeException.class);
     }
 
@@ -105,7 +105,7 @@ class SchedulesTest {
         Schedules schedules = createSchedules(schedule1, schedule2);
         Schedule updateSchedule = createNowDateSchedule(13, 18);
 
-        schedules.updateSchedule(updateSchedule, schedule2);
+        schedules.update(updateSchedule, schedule2);
 
         Schedule retSchedule = schedules.getSchedules().get(0);
         assertAll(
@@ -122,7 +122,7 @@ class SchedulesTest {
         Schedules schedules = createSchedules(schedule1, schedule2);
         Schedule updateSchedule = createNowDateSchedule(12, 18);
 
-        schedules.updateSchedule(updateSchedule, schedule2);
+        schedules.update(updateSchedule, schedule2);
 
         Schedule retSchedule = schedules.getSchedules().get(0);
         assertAll(
@@ -139,7 +139,7 @@ class SchedulesTest {
         Schedules schedules = createSchedules(schedule1, schedule2);
         Schedule updateSchedule = createNowDateSchedule(11, 18);
 
-        assertThatThrownBy(() -> schedules.updateSchedule(updateSchedule, schedule2))
+        assertThatThrownBy(() -> schedules.update(updateSchedule, schedule2))
             .isInstanceOf(ConflictingTimeException.class);
     }
 

--- a/src/test/java/com/modoospace/space/domain/TimeSettingsTest.java
+++ b/src/test/java/com/modoospace/space/domain/TimeSettingsTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.modoospace.common.exception.ConflictingTimeException;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -45,14 +44,6 @@ class TimeSettingsTest {
         List<Schedule> facilitySchedules = retTimeSettings.createSchedules(LocalDate.now());
 
         assertThat(facilitySchedules).hasSize(2);
-    }
-
-    @DisplayName("시설 세팅값이 비었다면 true를 던진다.")
-    @Test
-    public void isEmpty_returnTrue() {
-        TimeSettings timeSettings = new TimeSettings(new ArrayList<>());
-
-        assertThat(timeSettings.isEmpty()).isTrue();
     }
 
     private List<TimeSetting> createTimeSettings(TimeRange... timeRanges) {

--- a/src/test/java/com/modoospace/space/sevice/FacilityServiceTest.java
+++ b/src/test/java/com/modoospace/space/sevice/FacilityServiceTest.java
@@ -8,8 +8,8 @@ import com.modoospace.member.domain.MemberRepository;
 import com.modoospace.member.domain.Role;
 import com.modoospace.reservation.domain.DateTimeRange;
 import com.modoospace.space.controller.dto.facility.FacilityCreateRequest;
+import com.modoospace.space.controller.dto.facility.FacilitySettingUpdateRequest;
 import com.modoospace.space.controller.dto.facility.FacilityUpdateRequest;
-import com.modoospace.space.controller.dto.space.SpaceCreateUpdateRequest;
 import com.modoospace.space.controller.dto.timeSetting.TimeSettingCreateRequest;
 import com.modoospace.space.controller.dto.weekdaySetting.WeekdaySettingCreateRequest;
 import com.modoospace.space.domain.Category;
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -56,8 +57,10 @@ class FacilityServiceTest {
     private ScheduleQueryRepository scheduleQueryRepository;
 
     private Member hostMember;
+
     private Space space;
-    private LocalDate now;
+
+    private LocalDate workingDay;
 
     @BeforeEach
     public void setUp() {
@@ -79,12 +82,12 @@ class FacilityServiceTest {
             .build();
         spaceRepository.save(space);
 
-        now = LocalDate.now();
-        if (now.getDayOfWeek().equals(DayOfWeek.SUNDAY)) {
-            now = now.plusDays(1);
+        workingDay = LocalDate.now();
+        if (workingDay.getDayOfWeek().equals(DayOfWeek.SUNDAY)) {
+            workingDay = workingDay.plusDays(1);
         }
-        if (now.getDayOfWeek().equals(DayOfWeek.SATURDAY)) {
-            now = now.plusDays(2);
+        if (workingDay.getDayOfWeek().equals(DayOfWeek.SATURDAY)) {
+            workingDay = workingDay.plusDays(2);
         }
     }
 
@@ -92,7 +95,6 @@ class FacilityServiceTest {
     @Test
     public void createFacility_24HourOpen_ifNotSelectSetting() {
         FacilityCreateRequest createRequest = createFacility(true);
-
         Long facilityId = facilityService
             .createFacility(space.getId(), createRequest, hostMember.getEmail());
 
@@ -101,7 +103,28 @@ class FacilityServiceTest {
         assertThat(facility.getId()).isEqualTo(facilityId);
         assertThatFacilityInfo(facility, createRequest);
         assertThat(scheduleQueryRepository.isIncludingSchedule(facility,
-            new DateTimeRange(now, 0, now.plusDays(2), 24))).isTrue();
+            new DateTimeRange(workingDay, 0, workingDay.plusDays(2), 24))).isTrue();
+    }
+
+    private FacilityCreateRequest createFacility(Boolean enable) {
+        return FacilityCreateRequest.builder()
+            .name("스터디룸1")
+            .reservationEnable(enable)
+            .minUser(1)
+            .maxUser(4)
+            .description("1~4인실 입니다.")
+            .build();
+    }
+
+    private void assertThatFacilityInfo(Facility facility, FacilityCreateRequest request) {
+        assertAll(
+            () -> assertThat(facility.getName()).isEqualTo(request.getName()),
+            () -> assertThat(facility.getReservationEnable()).isEqualTo(
+                request.getReservationEnable()),
+            () -> assertThat(facility.getMinUser()).isEqualTo(request.getMinUser()),
+            () -> assertThat(facility.getMaxUser()).isEqualTo(request.getMaxUser()),
+            () -> assertThat(facility.getDescription()).isEqualTo(request.getDescription())
+        );
     }
 
     @DisplayName("시설 생성 시 시간, 요일 Setting에 맞게 예약이 가능한 시설이 생성된다.")
@@ -121,7 +144,31 @@ class FacilityServiceTest {
         assertThat(facility.getId()).isEqualTo(facilityId);
         assertThatFacilityInfo(facility, createRequest);
         assertThat(scheduleQueryRepository.isIncludingSchedule(facility,
-            new DateTimeRange(now, 9, now, 21))).isTrue();
+            new DateTimeRange(workingDay, 9, workingDay, 21))).isTrue();
+    }
+
+    private List<TimeSettingCreateRequest> createTimeSetting(Integer start, Integer end) {
+        return Arrays.asList(new TimeSettingCreateRequest(start, end));
+    }
+
+    private List<WeekdaySettingCreateRequest> createWeekDaySetting(DayOfWeek... dayOfWeeks) {
+        return Arrays.stream(dayOfWeeks)
+            .map(WeekdaySettingCreateRequest::new)
+            .collect(Collectors.toList());
+    }
+
+    private FacilityCreateRequest createFacilityWithSetting(Boolean enable,
+        List<TimeSettingCreateRequest> timeSettings,
+        List<WeekdaySettingCreateRequest> weekdaySettings) {
+        return FacilityCreateRequest.builder()
+            .name("스터디룸1")
+            .reservationEnable(enable)
+            .minUser(1)
+            .maxUser(4)
+            .description("1~4인실 입니다.")
+            .timeSettings(timeSettings)
+            .weekdaySettings(weekdaySettings)
+            .build();
     }
 
     @DisplayName("시설 정보를 업데이트한다.")
@@ -142,96 +189,62 @@ class FacilityServiceTest {
             .updateFacility(facilityId, updateRequest, hostMember.getEmail());
 
         Facility facility = facilityRepository.findById(facilityId).get();
-        assertThat(facility.getId()).isEqualTo(facilityId);
         assertThatFacilityInfo(facility, updateRequest);
-        assertThat(scheduleQueryRepository.isIncludingSchedule(facility,
-            new DateTimeRange(now, 0, now.plusDays(2), 24))).isTrue();
     }
 
-    @DisplayName("시설 정보와 세팅정보도 함께 업데이트한다.")
+    private void assertThatFacilityInfo(Facility facility, FacilityUpdateRequest request) {
+        assertAll(
+            () -> assertThat(facility.getName()).isEqualTo(request.getName()),
+            () -> assertThat(facility.getReservationEnable()).isEqualTo(
+                request.getReservationEnable()),
+            () -> assertThat(facility.getMinUser()).isEqualTo(request.getMinUser()),
+            () -> assertThat(facility.getMaxUser()).isEqualTo(request.getMaxUser()),
+            () -> assertThat(facility.getDescription()).isEqualTo(request.getDescription())
+        );
+    }
+
+    @DisplayName("시설시간 및 요일 세팅을 업데이트한다.")
     @Test
-    public void updateFacility_withSetting() {
-        FacilityCreateRequest createRequest = createFacility(false);
+    public void updateFacilitySetting() {
+        // 1. 시설 생성 Transaction(Commit)
         Long facilityId = facilityService
-            .createFacility(space.getId(), createRequest, hostMember.getEmail());
-        List<TimeSettingCreateRequest> timeSettings = createTimeSetting(9, 21);
-        List<WeekdaySettingCreateRequest> weekdaySettings = createWeekDaySetting(
-            DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY,
-            DayOfWeek.FRIDAY
+            .createFacility(space.getId(), createFacility(true), hostMember.getEmail());
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // 2. 시설 업데이트 및 검증 Transaction(Rollback)
+        TestTransaction.start();
+        updateFacilitySetting(facilityId);
+        assertThatSchedules(facilityId);
+        TestTransaction.end();
+
+        // 3. 생성된 데이터 삭제 Transaction(Commit)
+        TestTransaction.start();
+        deleteAll();
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+    }
+
+    private void updateFacilitySetting(Long facilityId) {
+        FacilitySettingUpdateRequest updateRequest = new FacilitySettingUpdateRequest(
+            createTimeSetting(9, 21),
+            createWeekDaySetting(
+                DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY,
+                DayOfWeek.FRIDAY)
         );
-        FacilityUpdateRequest updateRequest = FacilityUpdateRequest.builder()
-            .name("스터디룸2")
-            .reservationEnable(true)
-            .minUser(3)
-            .maxUser(6)
-            .description("3~6인실 입니다.")
-            .timeSettings(timeSettings)
-            .weekdaySettings(weekdaySettings)
-            .build();
+        facilityService.updateFacilitySetting(facilityId, updateRequest, hostMember.getEmail());
+    }
 
-        facilityService
-            .updateFacility(facilityId, updateRequest, hostMember.getEmail());
-
+    private void assertThatSchedules(Long facilityId) {
         Facility facility = facilityRepository.findById(facilityId).get();
-        assertThat(facility.getId()).isEqualTo(facilityId);
-        assertThatFacilityInfo(facility, updateRequest);
         assertThat(scheduleQueryRepository.isIncludingSchedule(facility,
-            new DateTimeRange(now, 9, now, 21))).isTrue();
+            new DateTimeRange(workingDay, 0, workingDay, 24))).isFalse();
     }
 
-    private FacilityCreateRequest createFacility(Boolean enable) {
-        return FacilityCreateRequest.builder()
-            .name("스터디룸1")
-            .reservationEnable(enable)
-            .minUser(1)
-            .maxUser(4)
-            .description("1~4인실 입니다.")
-            .build();
-    }
-
-    private FacilityCreateRequest createFacilityWithSetting(Boolean enable,
-        List<TimeSettingCreateRequest> timeSettings,
-        List<WeekdaySettingCreateRequest> weekdaySettings) {
-        return FacilityCreateRequest.builder()
-            .name("스터디룸1")
-            .reservationEnable(enable)
-            .minUser(1)
-            .maxUser(4)
-            .description("1~4인실 입니다.")
-            .timeSettings(timeSettings)
-            .weekdaySettings(weekdaySettings)
-            .build();
-    }
-
-    private List<TimeSettingCreateRequest> createTimeSetting(Integer start, Integer end) {
-        return Arrays.asList(new TimeSettingCreateRequest(start, end));
-    }
-
-    private List<WeekdaySettingCreateRequest> createWeekDaySetting(DayOfWeek... dayOfWeeks) {
-        return Arrays.stream(dayOfWeeks)
-            .map(WeekdaySettingCreateRequest::new)
-            .collect(Collectors.toList());
-    }
-
-    private void assertThatFacilityInfo(Facility facility, FacilityCreateRequest dto) {
-        assertAll(
-            () -> assertThat(facility.getName()).isEqualTo(dto.getName()),
-            () -> assertThat(facility.getReservationEnable()).isEqualTo(
-                dto.getReservationEnable()),
-            () -> assertThat(facility.getMinUser()).isEqualTo(dto.getMinUser()),
-            () -> assertThat(facility.getMaxUser()).isEqualTo(dto.getMaxUser()),
-            () -> assertThat(facility.getDescription()).isEqualTo(dto.getDescription())
-        );
-    }
-
-    private void assertThatFacilityInfo(Facility facility, FacilityUpdateRequest dto) {
-        assertAll(
-            () -> assertThat(facility.getName()).isEqualTo(dto.getName()),
-            () -> assertThat(facility.getReservationEnable()).isEqualTo(
-                dto.getReservationEnable()),
-            () -> assertThat(facility.getMinUser()).isEqualTo(dto.getMinUser()),
-            () -> assertThat(facility.getMaxUser()).isEqualTo(dto.getMaxUser()),
-            () -> assertThat(facility.getDescription()).isEqualTo(dto.getDescription())
-        );
+    private void deleteAll() {
+        facilityRepository.deleteAll();
+        spaceRepository.deleteAll();
+        categoryRepository.deleteAll();
+        memberRepository.deleteAll();
     }
 }

--- a/src/test/java/com/modoospace/space/sevice/FacilityServiceTest.java
+++ b/src/test/java/com/modoospace/space/sevice/FacilityServiceTest.java
@@ -148,7 +148,7 @@ class FacilityServiceTest {
     }
 
     private List<TimeSettingCreateRequest> createTimeSetting(Integer start, Integer end) {
-        return Arrays.asList(new TimeSettingCreateRequest(start, end));
+        return List.of(new TimeSettingCreateRequest(start, end));
     }
 
     private List<WeekdaySettingCreateRequest> createWeekDaySetting(DayOfWeek... dayOfWeeks) {
@@ -206,7 +206,7 @@ class FacilityServiceTest {
     @DisplayName("시설시간 및 요일 세팅을 업데이트한다.")
     @Test
     public void updateFacilitySetting() {
-        // 1. 시설 생성 Transaction(Commit)
+        // 1. 데이터 생성 Transaction(Commit)
         Long facilityId = facilityService
             .createFacility(space.getId(), createFacility(true), hostMember.getEmail());
         TestTransaction.flagForCommit();

--- a/src/test/java/com/modoospace/space/sevice/ScheduleServiceTest.java
+++ b/src/test/java/com/modoospace/space/sevice/ScheduleServiceTest.java
@@ -21,7 +21,6 @@ import com.modoospace.space.domain.Space;
 import com.modoospace.space.domain.SpaceRepository;
 import java.time.LocalDate;
 import java.time.YearMonth;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -29,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -87,7 +87,7 @@ public class ScheduleServiceTest {
             .minUser(1)
             .maxUser(4)
             .description("1~4인실 입니다.")
-            .timeSettings(Arrays.asList(new TimeSettingCreateRequest(9, 18)))
+            .timeSettings(List.of(new TimeSettingCreateRequest(9, 18)))
             .build();
         facility = facilityRepository.save(createRequest.toEntity(space));
 
@@ -253,11 +253,26 @@ public class ScheduleServiceTest {
     @DisplayName("이미 생성되어있는 1달 치 스케줄을 지우고 새로 생성한다.")
     @Test
     public void create1MonthDefaultFacilitySchedules_plus2Month() {
-        YearMonth createYearMonth = nowYearMonth.plusMonths(2);
+        // 1. 데이터 생성 Transaction(Commit)
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
 
+        // 2. 스케줄 생성 및 검증 Transaction(Rollback)
+        TestTransaction.start();
+        YearMonth createYearMonth = nowYearMonth.plusMonths(2);
         scheduleService.create1MonthDefaultSchedules(
             facility.getId(), createYearMonth, hostMember.getEmail());
+        assertAllSchedules(createYearMonth);
+        TestTransaction.end();
 
+        // 3. 생성된 데이터 삭제 Transaction(Commit)
+        TestTransaction.start();
+        deleteAll();
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+    }
+
+    private void assertAllSchedules(YearMonth createYearMonth) {
         List<ScheduleResponse> retResponses = scheduleService.find1MonthSchedules(
             facility.getId(), createYearMonth);
         assertAll(
@@ -268,6 +283,13 @@ public class ScheduleServiceTest {
                 retResponses.get(retResponses.size() - 1).getDate())
                 .isEqualTo(createYearMonth.atEndOfMonth())
         );
+    }
+
+    private void deleteAll() {
+        facilityRepository.deleteAllInBatch();
+        spaceRepository.deleteAllInBatch();
+        categoryRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
     }
 
     @DisplayName("1달 치 스케줄을 삭제한다.")

--- a/src/test/java/com/modoospace/space/sevice/ScheduleServiceTest.java
+++ b/src/test/java/com/modoospace/space/sevice/ScheduleServiceTest.java
@@ -286,10 +286,10 @@ public class ScheduleServiceTest {
     }
 
     private void deleteAll() {
-        facilityRepository.deleteAllInBatch();
-        spaceRepository.deleteAllInBatch();
-        categoryRepository.deleteAllInBatch();
-        memberRepository.deleteAllInBatch();
+        facilityRepository.deleteAll();
+        spaceRepository.deleteAll();
+        categoryRepository.deleteAll();
+        memberRepository.deleteAll();
     }
 
     @DisplayName("1달 치 스케줄을 삭제한다.")


### PR DESCRIPTION
## 개요
시설의 시간/요일 세팅 업데이트 시 3개월치 스케줄 데이터가 삭제 후 새로 생성됩니다.
이 경우 90여개의 삭제 쿼리가 한번에 나가게 되는데, 개선을 위해 한방쿼리로 변경하였습니다.
또한 시설을 삭제할 때도 관련된 스케줄을 먼저 한방쿼리로 삭제하도록 적용하였습니다.

## 작업사항
- 시설 업데이트/시설 세팅 업데이트 분리
- 시설 세팅 업데이트 전, 한방쿼리로 관련 스케줄데이터 삭제
- 시설 삭제 전, 한방쿼리로 관련 스케줄 데이터 삭제
- 테스트 수행시, ObjectOptimisticLockingFailureException 발생하여 트랜잭션 분리
  - https://velog.io/@gjwjdghk123/ObjectOptimisticLockingFailureException

## 변경로직
- 회원가입 시 회원정보 db저장 -> redis 저장으로 순서 변경
- 권한체크 도메인에서 서비스단으로 이동(쿼리 실행 전 검증 필요)

