### PR TITLE
[#43] testcoverage 80% 달성

### DIFF
--- a/.github/workflows/sonarcloud-analyze.yml
+++ b/.github/workflows/sonarcloud-analyze.yml
@@ -54,9 +54,9 @@ jobs:
           fi
           
 
-      - name: Analyze
-        run: ./gradlew sonar -Dsonar.projectKey=${{ env.SONAR_PROJECT_KEY }} -Dsonar.organization=f-lab-edu-1 -Dsonar.host.url=https://sonarcloud.io -Dsonar.token=${{ secrets.SECRET_SONARQUBE }} -Dsonar.gradle.skipCompile=true
-        env:
-          SONAR_TOKEN: ${{ secrets.SECRET_SONARQUBE }}
+#      - name: Analyze
+#        run: ./gradlew sonar -Dsonar.projectKey=${{ env.SONAR_PROJECT_KEY }} -Dsonar.organization=f-lab-edu-1 -Dsonar.host.url=https://sonarcloud.io -Dsonar.token=${{ secrets.SECRET_SONARQUBE }} -Dsonar.gradle.skipCompile=true
+#        env:
+#          SONAR_TOKEN: ${{ secrets.SECRET_SONARQUBE }}
 
           

--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'BRANCH'
                 value = 'COVEREDRATIO'
-                minimum = 0.5 // 테스트 커버리지 최소 50%
+                minimum = 0.8 // 테스트 커버리지 최소 80%
             }
 
             // 커버리지 체크를 제외할 클래스들

--- a/src/main/java/com/modoospace/alarm/controller/AlarmController.java
+++ b/src/main/java/com/modoospace/alarm/controller/AlarmController.java
@@ -1,17 +1,14 @@
 package com.modoospace.alarm.controller;
 
 import com.modoospace.alarm.controller.dto.AlarmResponse;
+import com.modoospace.alarm.domain.AlarmType;
 import com.modoospace.alarm.service.AlarmService;
 import com.modoospace.config.auth.LoginEmail;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RequiredArgsConstructor
@@ -19,24 +16,30 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequestMapping("/api/v1/alarms")
 public class AlarmController {
 
-  private final AlarmService alarmService;
+    private final AlarmService alarmService;
 
-  @GetMapping()
-  public ResponseEntity<Page<AlarmResponse>> search(@LoginEmail String loginEmail,
-      Pageable pageable) {
-    Page<AlarmResponse> alarms = alarmService.searchAlarms(loginEmail, pageable);
-    return ResponseEntity.ok().body(alarms);
-  }
+    @GetMapping()
+    public ResponseEntity<Page<AlarmResponse>> search(@LoginEmail String loginEmail,
+                                                      Pageable pageable) {
+        Page<AlarmResponse> alarms = alarmService.searchAlarms(loginEmail, pageable);
+        return ResponseEntity.ok().body(alarms);
+    }
 
-  @DeleteMapping("/{alarmId}")
-  public ResponseEntity<Void> delete(@PathVariable Long alarmId,
-      @LoginEmail String loginEmail) {
-    alarmService.delete(alarmId, loginEmail);
-    return ResponseEntity.noContent().build();
-  }
+    @DeleteMapping("/{alarmId}")
+    public ResponseEntity<Void> delete(@PathVariable Long alarmId,
+                                       @LoginEmail String loginEmail) {
+        alarmService.delete(alarmId, loginEmail);
+        return ResponseEntity.noContent().build();
+    }
 
-  @GetMapping("/subscribe")
-  public SseEmitter subscribe(@LoginEmail String loginEmail) {
-    return alarmService.connectAlarm(loginEmail);
-  }
+    @GetMapping(value = "/subscribe", produces = "text/event-stream")
+    public ResponseEntity<SseEmitter> subscribe(@LoginEmail String loginEmail) {
+        return ResponseEntity.ok(alarmService.connectAlarm(loginEmail));
+    }
+
+    @PostMapping(value = "/send/{email}")
+    public ResponseEntity<Void> send(@PathVariable String email) {
+        alarmService.send(email, new AlarmResponse(null, null, "테스트시설", AlarmType.NEW_RESERVATION));
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/modoospace/alarm/controller/dto/AlarmResponse.java
+++ b/src/main/java/com/modoospace/alarm/controller/dto/AlarmResponse.java
@@ -1,11 +1,13 @@
 package com.modoospace.alarm.controller.dto;
 
+import com.modoospace.alarm.domain.Alarm;
 import com.modoospace.alarm.domain.AlarmType;
-import java.io.Serializable;
-import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
 
 @Getter
 @NoArgsConstructor
@@ -25,5 +27,14 @@ public class AlarmResponse implements Serializable {
         this.id = id;
         this.reservationId = reservationId;
         this.message = facilityName + alarmType.getAlarmText();
+    }
+
+    public static AlarmResponse of(Alarm alarm) {
+        return AlarmResponse.builder()
+                .id(alarm.getId())
+                .reservationId(alarm.getReservationId())
+                .facilityName(alarm.getFacilityName())
+                .alarmType(alarm.getAlarmType())
+                .build();
     }
 }

--- a/src/main/java/com/modoospace/alarm/repository/AlarmQueryRepository.java
+++ b/src/main/java/com/modoospace/alarm/repository/AlarmQueryRepository.java
@@ -1,15 +1,11 @@
 package com.modoospace.alarm.repository;
 
-import static com.modoospace.alarm.domain.QAlarm.alarm;
-
 import com.modoospace.alarm.controller.dto.AlarmResponse;
 import com.modoospace.alarm.domain.Alarm;
 import com.modoospace.member.domain.Member;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
@@ -17,39 +13,39 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+import static com.modoospace.alarm.domain.QAlarm.alarm;
+
 @RequiredArgsConstructor
 @Repository
 public class AlarmQueryRepository {
 
-  private final JPAQueryFactory jpaQueryFactory;
+    private final JPAQueryFactory jpaQueryFactory;
 
-  @Cacheable(cacheNames = "searchAlarms", key = "#member.email +':'+ #pageable.pageNumber")
-  public Page<AlarmResponse> searchByMember(Member member, Pageable pageable) {
+    @Cacheable(cacheNames = "searchAlarms", key = "#member.email +':'+ #pageable.pageNumber")
+    public Page<AlarmResponse> searchByMember(Member member, Pageable pageable) {
 
-    List<AlarmResponse> content = jpaQueryFactory
-        .select(
-            Projections.constructor(AlarmResponse.class
-                , alarm.id
-                , alarm.reservationId
-                , alarm.facilityName
-                , alarm.alarmType
-            )
-        )
-        .from(alarm)
-        .where(emailEq(member.getEmail()))
-        .offset(pageable.getOffset())
-        .limit(pageable.getPageSize())
-        .orderBy(alarm.createdTime.desc())
-        .fetch();
+        List<AlarmResponse> content = jpaQueryFactory
+                .select(
+                        Projections.constructor(AlarmResponse.class
+                                , alarm.id
+                                , alarm.reservationId
+                                , alarm.facilityName
+                                , alarm.alarmType
+                        )
+                )
+                .from(alarm)
+                .where(alarm.email.eq(member.getEmail()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(alarm.createdTime.desc())
+                .fetch();
 
-    JPAQuery<Alarm> countQuery = jpaQueryFactory
-        .selectFrom(alarm)
-        .where(emailEq(member.getEmail()));
+        JPAQuery<Alarm> countQuery = jpaQueryFactory
+                .selectFrom(alarm)
+                .where(alarm.email.eq(member.getEmail()));
 
-    return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
-  }
-
-  private BooleanExpression emailEq(String email) {
-    return email != null ? alarm.email.eq(email) : null;
-  }
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
+    }
 }

--- a/src/main/java/com/modoospace/alarm/repository/EmitterLocalCacheRepository.java
+++ b/src/main/java/com/modoospace/alarm/repository/EmitterLocalCacheRepository.java
@@ -1,0 +1,33 @@
+package com.modoospace.alarm.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class EmitterLocalCacheRepository {
+
+    private final Map<String, SseEmitter> sseEmitterMap = new HashMap<>();
+
+    public SseEmitter save(String id, SseEmitter sseEmitter) {
+        sseEmitterMap.put(getKey(id), sseEmitter);
+        return sseEmitter;
+    }
+
+    public Optional<SseEmitter> find(String id) {
+        return Optional.ofNullable(sseEmitterMap.get(getKey(id)));
+    }
+
+    public void delete(String id) {
+        sseEmitterMap.remove(id);
+    }
+
+    private String getKey(String id) {
+        return "SSE:" + id;
+    }
+}

--- a/src/main/java/com/modoospace/config/auth/SecurityConfiguration.java
+++ b/src/main/java/com/modoospace/config/auth/SecurityConfiguration.java
@@ -12,28 +12,29 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 public class SecurityConfiguration {
 
-  private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomOAuth2UserService customOAuth2UserService;
 
-  @Bean
-  protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.csrf().disable().cors().disable()
-        .headers().frameOptions().disable() // h2-console화면을 사용하기 위해 해당 옵션들을 disable
-        .and()
-        .authorizeHttpRequests(request -> request
-                .antMatchers(HttpMethod.GET, "/", "/error", "/api/v1/spaces/**",
-                    "/api/v1/spaces/*/facilities/**",
-                    "/api/v1/facilities/*/schedules/**",
-                    "/api/v1/visitors/reservations/facilities/*/availability/**").permitAll()
+    @Bean
+    protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable().cors().disable()
+                .headers().frameOptions().disable() // h2-console화면을 사용하기 위해 해당 옵션들을 disable
+                .and()
+                .authorizeHttpRequests(request -> request
+                                .antMatchers(HttpMethod.GET, "/", "/error", "/api/v1/spaces/**",
+                                        "/api/v1/spaces/*/facilities/**",
+                                        "/api/v1/facilities/*/schedules/**",
+                                        "/api/v1/visitors/reservations/facilities/*/availability/**").permitAll()
+                                .antMatchers(HttpMethod.POST, "/api/v1/alarms/send/**").permitAll()
 //            .antMatchers(HttpMethod.POST, "/api/v1/space").hasRole(Role.HOST.name())
-                .antMatchers("/api/v1/admin/**").hasRole(Role.ADMIN.name())
-                .anyRequest().authenticated()
-        )
-        .oauth2Login().userInfoEndpoint()
-        .userService(customOAuth2UserService); // 로그인 성공 후 후속조치를 진행할 UserServie 인터페이스의 구현체 등록
+                                .antMatchers("/api/v1/admin/**").hasRole(Role.ADMIN.name())
+                                .anyRequest().authenticated()
+                )
+                .oauth2Login().userInfoEndpoint()
+                .userService(customOAuth2UserService); // 로그인 성공 후 후속조치를 진행할 UserServie 인터페이스의 구현체 등록
 
-    http.logout()
-        .logoutSuccessUrl("/")
-        .invalidateHttpSession(true); // 세션 날리기
-    return http.build();
-  }
+        http.logout()
+                .logoutSuccessUrl("/")
+                .invalidateHttpSession(true); // 세션 날리기
+        return http.build();
+    }
 }

--- a/src/main/java/com/modoospace/reservation/controller/dto/ReservationResponse.java
+++ b/src/main/java/com/modoospace/reservation/controller/dto/ReservationResponse.java
@@ -6,12 +6,13 @@ import com.modoospace.member.controller.dto.MemberResponse;
 import com.modoospace.reservation.domain.Reservation;
 import com.modoospace.reservation.domain.ReservationStatus;
 import com.modoospace.space.controller.dto.facility.FacilityResponse;
-import java.time.LocalDate;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
@@ -42,12 +43,12 @@ public class ReservationResponse {
     private FacilityResponse facility;
 
     @NotEmpty
-    private MemberResponse member;
+    private MemberResponse visitor;
 
     @Builder
     public ReservationResponse(Long id, Integer numOrUser, LocalDate startDate, Integer startHour,
-        LocalDate endDate, Integer endHour, ReservationStatus status, FacilityResponse facility,
-        MemberResponse member) {
+                               LocalDate endDate, Integer endHour, ReservationStatus status, FacilityResponse facility,
+                               MemberResponse visitor) {
         this.id = id;
         this.numOrUser = numOrUser;
         this.startDate = startDate;
@@ -56,21 +57,21 @@ public class ReservationResponse {
         this.endHour = endHour;
         this.status = status;
         this.facility = facility;
-        this.member = member;
+        this.visitor = visitor;
     }
 
 
     public static ReservationResponse of(Reservation reservation) {
         return ReservationResponse.builder()
-            .id(reservation.getId())
-            .numOrUser(reservation.getNumOfUser())
-            .startDate(reservation.getStartDate())
-            .startHour(reservation.getStartHour())
-            .endDate(reservation.getEndDate())
-            .endHour(reservation.getEndHour())
-            .status(reservation.getStatus())
-            .facility(FacilityResponse.of(reservation.getFacility()))
-            .member(MemberResponse.of(reservation.getVisitor()))
-            .build();
+                .id(reservation.getId())
+                .numOrUser(reservation.getNumOfUser())
+                .startDate(reservation.getStartDate())
+                .startHour(reservation.getStartHour())
+                .endDate(reservation.getEndDate())
+                .endHour(reservation.getEndHour())
+                .status(reservation.getStatus())
+                .facility(FacilityResponse.of(reservation.getFacility()))
+                .visitor(MemberResponse.of(reservation.getVisitor()))
+                .build();
     }
 }

--- a/src/main/java/com/modoospace/reservation/repository/ReservationQueryRepository.java
+++ b/src/main/java/com/modoospace/reservation/repository/ReservationQueryRepository.java
@@ -1,18 +1,17 @@
 package com.modoospace.reservation.repository;
 
-import static com.modoospace.reservation.domain.QReservation.reservation;
-
 import com.modoospace.reservation.domain.DateTimeRange;
 import com.modoospace.reservation.domain.Reservation;
 import com.modoospace.reservation.domain.ReservationStatus;
 import com.modoospace.space.domain.Facility;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.modoospace.reservation.domain.QReservation.reservation;
 
 @RequiredArgsConstructor
 @Repository
@@ -28,31 +27,15 @@ public class ReservationQueryRepository {
         return !findConflictingReservation(facility, dateTimeRange).isEmpty();
     }
 
-    private List<Reservation> findConflictingReservation(Facility facility,
-        DateTimeRange dateTimeRange) {
+    private List<Reservation> findConflictingReservation(Facility facility, DateTimeRange dateTimeRange) {
 
         return jpaQueryFactory
-            .selectFrom(reservation)
-            .where(facilityEq(facility),
-                statusNe(ReservationStatus.CANCELED),
-                startDateTimeBefore(dateTimeRange.getEndDateTime()),
-                endDateTimeAfter(dateTimeRange.getStartDateTime()))
-            .fetch();
-    }
-
-    private BooleanExpression facilityEq(Facility facility) {
-        return facility != null ? reservation.facility.eq(facility) : null;
-    }
-
-    private BooleanExpression statusNe(ReservationStatus status) {
-        return status != null ? reservation.status.ne(status) : null;
-    }
-
-    private BooleanExpression startDateTimeBefore(LocalDateTime dateTime) {
-        return dateTime != null ? reservation.dateTimeRange.startDateTime.before(dateTime) : null;
-    }
-
-    private BooleanExpression endDateTimeAfter(LocalDateTime dateTime) {
-        return dateTime != null ? reservation.dateTimeRange.endDateTime.after(dateTime) : null;
+                .selectFrom(reservation)
+                .where(reservation.facility.eq(facility),
+                        reservation.status.ne(ReservationStatus.CANCELED),
+                        reservation.dateTimeRange.startDateTime.before(dateTimeRange.getEndDateTime()),
+                        reservation.dateTimeRange.endDateTime.after(dateTimeRange.getStartDateTime())
+                )
+                .fetch();
     }
 }

--- a/src/main/java/com/modoospace/reservation/serivce/ReservationService.java
+++ b/src/main/java/com/modoospace/reservation/serivce/ReservationService.java
@@ -58,6 +58,7 @@ public class ReservationService {
     }
 
     private void verifyAvailability(Facility facility, Reservation reservation) {
+        facility.verifyReservationEnable();
         verifyFacilitySchedulesOpen(facility, reservation);
         verifyReservationAvailability(facility, reservation);
     }

--- a/src/main/java/com/modoospace/space/controller/FacilityController.java
+++ b/src/main/java/com/modoospace/space/controller/FacilityController.java
@@ -41,10 +41,10 @@ public class FacilityController {
 
     @GetMapping()
     public ResponseEntity<Page<FacilityResponse>> search(@PathVariable Long spaceId,
-        FacilitySearchRequest searchDto, Pageable pageable) {
-        Page<FacilityResponse> facilityReadDtos = facilityService
-            .searchFacility(spaceId, searchDto, pageable);
-        return ResponseEntity.ok().body(facilityReadDtos);
+        FacilitySearchRequest searchRequest, Pageable pageable) {
+        Page<FacilityResponse> facilityResponses = facilityService
+            .searchFacility(spaceId, searchRequest, pageable);
+        return ResponseEntity.ok().body(facilityResponses);
     }
 
     @GetMapping("/{facilityId}")

--- a/src/main/java/com/modoospace/space/repository/FacilityQueryRepository.java
+++ b/src/main/java/com/modoospace/space/repository/FacilityQueryRepository.java
@@ -26,7 +26,7 @@ public class FacilityQueryRepository {
 
         List<Facility> content = jpaQueryFactory
                 .selectFrom(facility)
-                .where(spaceIdEq(spaceId)
+                .where(facility.space.id.eq(spaceId)
                         , nameContains(searchRequest.getName())
                         , reservationEnableEq(searchRequest.getReservationEnable()))
                 .offset(pageable.getOffset())
@@ -35,15 +35,11 @@ public class FacilityQueryRepository {
 
         JPAQuery<Facility> countQuery = jpaQueryFactory
                 .selectFrom(facility)
-                .where(spaceIdEq(spaceId)
+                .where(facility.space.id.eq(spaceId)
                         , nameContains(searchRequest.getName())
                         , reservationEnableEq(searchRequest.getReservationEnable()));
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
-    }
-
-    private BooleanExpression spaceIdEq(Long spaceId) {
-        return spaceId != null ? facility.space.id.eq(spaceId) : null;
     }
 
     private BooleanExpression nameContains(String name) {

--- a/src/main/java/com/modoospace/space/repository/ScheduleQueryRepository.java
+++ b/src/main/java/com/modoospace/space/repository/ScheduleQueryRepository.java
@@ -1,19 +1,20 @@
 package com.modoospace.space.repository;
 
-import static com.modoospace.space.domain.QSchedule.schedule;
-
 import com.modoospace.reservation.domain.DateTimeRange;
 import com.modoospace.space.domain.Facility;
 import com.modoospace.space.domain.Schedule;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.Period;
 import java.time.YearMonth;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
+
+import static com.modoospace.space.domain.QSchedule.schedule;
 
 @RequiredArgsConstructor
 @Repository
@@ -31,106 +32,93 @@ public class ScheduleQueryRepository {
         // 같은 날짜의 시간범위를 체크하는 경우 ex) x월x일 13~18시
         if (startDate.isEqual(endDate)) {
             return isIncludingSchedule(facility, startDate,
-                dateTimeRange.getStartTime(), dateTimeRange.getEndTime());
+                    dateTimeRange.getStartTime(), dateTimeRange.getEndTime());
         }
 
         // 다른 날짜의 시간범위를 체크하는 경우 ex) x월x일 13시~ x월(x+n)일 18시
         // 1. 첫째날 13~24시
         if (isIncludingSchedule(facility, startDate,
-            dateTimeRange.getStartTime(), LocalTime.of(23, 59))) {
+                dateTimeRange.getStartTime(), LocalTime.of(23, 59))) {
             // 2. 중간날 0~24시
             int days = Period.between(startDate, endDate).getDays();
             for (int i = 1; i < days; i++) {
                 if (!isIncludingSchedule(facility, startDate.plusDays(i),
-                    LocalTime.of(0, 0), LocalTime.of(23, 59))) {
+                        LocalTime.of(0, 0), LocalTime.of(23, 59))) {
                     return false;
                 }
             }
             // 3. 마지막날 0~18시
             return isIncludingSchedule(facility, endDate,
-                LocalTime.of(0, 0), dateTimeRange.getEndTime());
+                    LocalTime.of(0, 0), dateTimeRange.getEndTime());
         }
 
         return false;
     }
 
     private boolean isIncludingSchedule(Facility facility, LocalDate date, LocalTime startTime,
-        LocalTime endTime) {
+                                        LocalTime endTime) {
         return getIncludingSchedule(facility, date, startTime, endTime) != null;
     }
 
-    private Schedule getIncludingSchedule(Facility facility, LocalDate date, LocalTime startTime,
-        LocalTime endTime) {
+    private Schedule getIncludingSchedule(Facility facility, LocalDate date, LocalTime startTime, LocalTime endTime) {
         return jpaQueryFactory
-            .selectFrom(schedule)
-            .where(
-                facilityEq(facility)
-                , dateEq(date)
-                , includingTimeRange(startTime, endTime)
-            )
-            .fetchFirst();
+                .selectFrom(schedule)
+                .where(
+                        schedule.facility.eq(facility)
+                        , schedule.date.eq(date)
+                        , includingTimeRange(startTime, endTime)
+                )
+                .fetchFirst();
     }
 
     public List<Schedule> find1DaySchedules(Facility facility, LocalDate findDate) {
         return jpaQueryFactory
-            .selectFrom(schedule)
-            .where(facilityEq(facility)
-                , dateEq(findDate))
-            .orderBy(schedule.date.asc())
-            .orderBy(schedule.timeRange.startTime.asc())
-            .fetch();
+                .selectFrom(schedule)
+                .where(schedule.facility.eq(facility)
+                        , schedule.date.eq(findDate))
+                .orderBy(schedule.date.asc())
+                .orderBy(schedule.timeRange.startTime.asc())
+                .fetch();
     }
 
     public List<Schedule> find1MonthSchedules(Facility facility,
-        YearMonth findYearMonth) {
+                                              YearMonth findYearMonth) {
         LocalDate startDate = findYearMonth.atDay(1);
         LocalDate endDate = findYearMonth.atEndOfMonth();
 
         return jpaQueryFactory
-            .selectFrom(schedule)
-            .where(facilityEq(facility)
-                , dateBetween(startDate, endDate))
-            .orderBy(schedule.date.asc())
-            .orderBy(schedule.timeRange.startTime.asc())
-            .fetch();
+                .selectFrom(schedule)
+                .where(schedule.facility.eq(facility)
+                        , dateBetween(startDate, endDate))
+                .orderBy(schedule.date.asc())
+                .orderBy(schedule.timeRange.startTime.asc())
+                .fetch();
     }
 
     public void delete1MonthSchedules(Facility facility,
-        YearMonth findYearMonth) {
+                                      YearMonth findYearMonth) {
         LocalDate startDate = findYearMonth.atDay(1);
         LocalDate endDate = findYearMonth.atEndOfMonth();
 
         jpaQueryFactory
-            .delete(schedule)
-            .where(facilityEq(facility)
-                , dateBetween(startDate, endDate))
-            .execute();
+                .delete(schedule)
+                .where(schedule.facility.eq(facility)
+                        , dateBetween(startDate, endDate))
+                .execute();
     }
 
     public void deleteFacilitySchedules(Facility facility) {
         jpaQueryFactory
-            .delete(schedule)
-            .where(facilityEq(facility))
-            .execute();
-    }
-
-    private BooleanExpression facilityEq(Facility facility) {
-        return facility != null ? schedule.facility.eq(facility) : null;
-    }
-
-    private BooleanExpression dateEq(LocalDate date) {
-        return date != null ? schedule.date.eq(date) : null;
+                .delete(schedule)
+                .where(schedule.facility.eq(facility))
+                .execute();
     }
 
     private BooleanExpression dateBetween(LocalDate startDate, LocalDate endDate) {
-        return startDate != null && endDate != null ? schedule.date.between(startDate, endDate)
-            : null;
+        return schedule.date.between(startDate, endDate);
     }
 
-    private BooleanExpression includingTimeRange(LocalTime startTime,
-        LocalTime endTime) {
-        return startTime != null && endTime != null ?
-            (schedule.timeRange.startTime.loe(startTime))
-                .and((schedule.timeRange.endTime.goe(endTime))) : null;
+    private BooleanExpression includingTimeRange(LocalTime startTime, LocalTime endTime) {
+        return (schedule.timeRange.startTime.loe(startTime)).and((schedule.timeRange.endTime.goe(endTime)));
     }
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,28 +1,69 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-  <title>Modoo Space</title>
-  <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
-
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+    <title>Modoo Space</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
 </head>
+<script type="text/javaScript">
+    function subscribe() {
+        const eventSource = new EventSource(`/api/v1/alarms/subscribe`);
+        eventSource.addEventListener("sse", function (event) {
+            console.log(event.data);
+            try {
+                const data = JSON.parse(event.data);
+
+                // 브라우저 알림
+                const showNotification = () => {
+                    const options = {
+                        body: data.message,
+                    };
+                    const notification = new Notification('Notification', options);
+                    notification.onclick = function () {
+                        // 사용자가 알림을 클릭했을 때의 동작
+                        alert('예약 조회 url 필요.');
+                    };
+                };
+
+                // 브라우저 알림 허용 권한
+                if (!("Notification" in window)) {
+                    console.log('Desktop notifications are not available in your browser.');
+                    return;
+                }
+
+                if (Notification.permission === 'granted') {
+                    // 이미 권한이 부여되었다면 알림을 바로 보여줍니다.
+                    showNotification();
+                } else if (Notification.permission !== 'denied') {
+                    Notification.requestPermission().then(permission => {
+                        if (permission === 'granted') {
+                            showNotification();
+                        }
+                    });
+                }
+            } catch (error) {
+
+            }
+        });
+    }
+</script>
+
 <body>
 <div class="page-header">
-  <h1>Modoo Space</h1>
+    <h1>Modoo Space</h1>
 </div>
-
 <div class="row">
-  <div class="col-md-6" th:if="${userName != null}">
-    <span th:text="'Logged in as: ' + ${userName}"/>
-    <a href="/logout" class="btn btn-info active" role="button">Logout</a>
-  </div>
-  <div class="col-md-6" th:if="${userName == null}">
-    <a href="/oauth2/authorization/google" class="btn btn-primary active" role="button">Google Login</a>
-    <a href="/oauth2/authorization/naver" class="btn btn-success active" role="button">Naver Login</a>
-    <a href="/oauth2/authorization/kakao" class="btn btn-warning active" role="button">KaKao Login</a>
-  </div>
+    <div class="col-md-6" th:if="${userName != null}">
+        <span th:text="'Logged in as: ' + ${userName}"/>
+        <a href="/logout" class="btn btn-info active" role="button">Logout</a>
+        <button type="button" class="btn btn-primary active" onclick="subscribe()">알람구독</button>
+    </div>
+    <div class="col-md-6" th:if="${userName == null}">
+        <a href="/oauth2/authorization/google" class="btn btn-primary active" role="button">Google Login</a>
+        <a href="/oauth2/authorization/naver" class="btn btn-success active" role="button">Naver Login</a>
+        <a href="/oauth2/authorization/kakao" class="btn btn-warning active" role="button">KaKao Login</a>
+    </div>
 </div>
-
 <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 </body>

--- a/src/test/java/com/modoospace/alarm/domain/AlarmTest.java
+++ b/src/test/java/com/modoospace/alarm/domain/AlarmTest.java
@@ -1,0 +1,64 @@
+package com.modoospace.alarm.domain;
+
+import com.modoospace.common.exception.PermissionDeniedException;
+import com.modoospace.member.domain.Member;
+import com.modoospace.member.domain.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AlarmTest {
+
+    private Member host;
+    private Member admin;
+    private Member visitor;
+    private Alarm alarm;
+
+    @BeforeEach
+    public void setup() {
+        host = Member.builder()
+                .id(1L)
+                .email("host@email")
+                .name("host")
+                .role(Role.HOST)
+                .build();
+
+        admin = Member.builder()
+                .id(1L)
+                .email("admin@email")
+                .name("admin")
+                .role(Role.ADMIN)
+                .build();
+
+        visitor = Member.builder()
+                .id(1L)
+                .email("visitor@email")
+                .name("visitor")
+                .role(Role.VISITOR)
+                .build();
+
+        alarm = Alarm.builder()
+                .id(1L)
+                .email(host.getEmail())
+                .reservationId(1L)
+                .facilityName("테스트시설")
+                .alarmType(AlarmType.NEW_RESERVATION)
+                .build();
+    }
+
+    @DisplayName("알람 주인이 아니면 예외를 던진다.")
+    @Test
+    public void verifyManagementPermission_throwException_ifNotAlarmOwner() {
+        assertThatThrownBy(() -> alarm.verifyManagementPermission(visitor))
+                .isInstanceOf(PermissionDeniedException.class);
+    }
+
+    @DisplayName("알람 주인 또는 Admin일 경우 검증을 통과한다.")
+    @Test
+    public void verifyManagementPermission_ifAlarmOwnerOrAdmin() {
+        alarm.verifyManagementPermission(admin);
+        alarm.verifyManagementPermission(host);
+    }
+}

--- a/src/test/java/com/modoospace/alarm/repository/EmitterCacheRepositoryTest.java
+++ b/src/test/java/com/modoospace/alarm/repository/EmitterCacheRepositoryTest.java
@@ -23,7 +23,7 @@ class EmitterCacheRepositoryTest extends AbstractIntegrationContainerBaseTest {
         sseEmitter = new SseEmitter(60L * 1000 * 60);
     }
 
-    @DisplayName("SseEmitter를 \'SSE:이메일\' 을 키값으로 저장한다.")
+    @DisplayName("SseEmitter를 'SSE:이메일' 을 키값으로 저장한다.")
     @Test
     public void save() {
         emitterCacheRepository.save("test@email.com", sseEmitter);
@@ -32,7 +32,7 @@ class EmitterCacheRepositoryTest extends AbstractIntegrationContainerBaseTest {
         assertThat(retSseEmitter).isNotEmpty();
     }
 
-    @DisplayName("SseEmitter를 \'SSE:이메일\' 을 키값으로 삭제한다.")
+    @DisplayName("SseEmitter를 'SSE:이메일' 을 키값으로 삭제한다.")
     @Test
     public void delete() {
         emitterCacheRepository.save("test@email.com", sseEmitter);

--- a/src/test/java/com/modoospace/alarm/repository/EmitterCacheRepositoryTest.java
+++ b/src/test/java/com/modoospace/alarm/repository/EmitterCacheRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.modoospace.alarm.repository;
+
+import com.modoospace.AbstractIntegrationContainerBaseTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EmitterCacheRepositoryTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private EmitterCacheRepository emitterCacheRepository;
+
+    private SseEmitter sseEmitter;
+
+    @BeforeEach
+    public void setup() {
+        sseEmitter = new SseEmitter(60L * 1000 * 60);
+    }
+
+    @DisplayName("SseEmitter를 \'SSE:이메일\' 을 키값으로 저장한다.")
+    @Test
+    public void save() {
+        emitterCacheRepository.save("test@email.com", sseEmitter);
+
+        Optional<SseEmitter> retSseEmitter = emitterCacheRepository.findByEmail("test@email.com");
+        assertThat(retSseEmitter).isNotEmpty();
+    }
+
+    @DisplayName("SseEmitter를 \'SSE:이메일\' 을 키값으로 삭제한다.")
+    @Test
+    public void delete() {
+        emitterCacheRepository.save("test@email.com", sseEmitter);
+
+        emitterCacheRepository.delete("test@email.com");
+
+        Optional<SseEmitter> retSseEmitter = emitterCacheRepository.findByEmail("test@email.com");
+        assertThat(retSseEmitter).isEmpty();
+    }
+}

--- a/src/test/java/com/modoospace/reservation/repository/ReservationQueryRepositoryTest.java
+++ b/src/test/java/com/modoospace/reservation/repository/ReservationQueryRepositoryTest.java
@@ -1,7 +1,5 @@
 package com.modoospace.reservation.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.modoospace.JpaTestConfig;
 import com.modoospace.member.domain.Member;
 import com.modoospace.member.domain.MemberRepository;
@@ -10,14 +8,7 @@ import com.modoospace.reservation.domain.DateTimeRange;
 import com.modoospace.reservation.domain.Reservation;
 import com.modoospace.reservation.domain.ReservationRepository;
 import com.modoospace.space.controller.dto.facility.FacilityCreateRequest;
-import com.modoospace.space.domain.Category;
-import com.modoospace.space.domain.CategoryRepository;
-import com.modoospace.space.domain.Facility;
-import com.modoospace.space.domain.FacilityRepository;
-import com.modoospace.space.domain.Space;
-import com.modoospace.space.domain.SpaceRepository;
-import java.time.LocalDate;
-import java.util.List;
+import com.modoospace.space.domain.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +16,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @Import(JpaTestConfig.class)
@@ -58,38 +54,38 @@ public class ReservationQueryRepositoryTest {
     @BeforeEach
     public void setUp() {
         Member hostMember = Member.builder()
-            .email("host@email")
-            .name("host")
-            .role(Role.HOST)
-            .build();
+                .email("host@email")
+                .name("host")
+                .role(Role.HOST)
+                .build();
         memberRepository.save(hostMember);
 
         visitorMember = Member.builder()
-            .email("visitor@email")
-            .name("visitor")
-            .role(Role.VISITOR)
-            .build();
+                .email("visitor@email")
+                .name("visitor")
+                .role(Role.VISITOR)
+                .build();
         memberRepository.save(visitorMember);
 
         Category category = new Category("스터디 공간");
         categoryRepository.save(category);
 
         Space space = Space.builder()
-            .name("공간이름")
-            .description("설명")
-            .category(category)
-            .host(hostMember)
-            .build();
+                .name("공간이름")
+                .description("설명")
+                .category(category)
+                .host(hostMember)
+                .build();
         spaceRepository.save(space);
 
         // TimeSetting, WeekSetting 기본값이 필요하여 Request 사용.
         FacilityCreateRequest createRequest = FacilityCreateRequest.builder()
-            .name("스터디룸")
-            .reservationEnable(true)
-            .minUser(1)
-            .maxUser(4)
-            .description("1~4인실 입니다.")
-            .build();
+                .name("스터디룸")
+                .reservationEnable(true)
+                .minUser(1)
+                .maxUser(4)
+                .description("1~4인실 입니다.")
+                .build();
         facility = facilityRepository.save(createRequest.toEntity(space));
 
         now = LocalDate.now();
@@ -97,45 +93,72 @@ public class ReservationQueryRepositoryTest {
 
     @Test
     @DisplayName("해당 날짜에 존재하는 활성화된 예약을 반환한다.")
-    public void findActiveReservations() {
+    public void findActiveReservations_returnActiveReservationList() {
         DateTimeRange dateTimeRange = new DateTimeRange(now, 13, now, 16);
         Reservation reservation1 = Reservation.builder()
-            .numOfUser(3)
-            .dateTimeRange(dateTimeRange)
-            .visitor(visitorMember)
-            .facility(facility)
-            .build();
+                .numOfUser(3)
+                .dateTimeRange(dateTimeRange)
+                .visitor(visitorMember)
+                .facility(facility)
+                .build();
         reservationRepository.save(reservation1);
         DateTimeRange dateTimeRange2 = new DateTimeRange(now, 22, now.plusDays(1), 2);
         Reservation reservation2 = Reservation.builder()
-            .numOfUser(3)
-            .dateTimeRange(dateTimeRange2)
-            .visitor(visitorMember)
-            .facility(facility)
-            .build();
+                .numOfUser(3)
+                .dateTimeRange(dateTimeRange2)
+                .visitor(visitorMember)
+                .facility(facility)
+                .build();
         reservationRepository.save(reservation2);
 
         List<Reservation> activeReservations = reservationQueryRepository.findActiveReservations(
-            facility, now);
+                facility, now);
 
         assertThat(activeReservations).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("해당 날짜에 존재하는 활성화된 예약이 없다면 빈List를 반환한다.")
+    public void findActiveReservations_returnEmptyList() {
+        List<Reservation> activeReservations = reservationQueryRepository.findActiveReservations(
+                facility, now);
+
+        assertThat(activeReservations).isEmpty();
     }
 
 
     @Test
     @DisplayName("동일한 시설,시간에 기존 예약이 있다면 true를 반환한다.")
-    public void isConflictingReservation() {
+    public void isConflictingReservation_returnTrue() {
         DateTimeRange dateTimeRange = new DateTimeRange(now, 13, now, 16);
         Reservation reservation1 = Reservation.builder()
-            .numOfUser(3)
-            .dateTimeRange(dateTimeRange)
-            .visitor(visitorMember)
-            .facility(facility)
-            .build();
+                .numOfUser(3)
+                .dateTimeRange(dateTimeRange)
+                .visitor(visitorMember)
+                .facility(facility)
+                .build();
         reservationRepository.save(reservation1);
 
         Boolean isExist = reservationQueryRepository
-            .isConflictingReservation(facility, dateTimeRange);
+                .isConflictingReservation(facility, dateTimeRange);
         assertThat(isExist).isTrue();
+    }
+
+    @Test
+    @DisplayName("동일한 시설,시간에 기존 예약이 있다면 true를 반환한다.")
+    public void isConflictingReservation_returnFalse() {
+        DateTimeRange dateTimeRange = new DateTimeRange(now, 13, now, 16);
+        Reservation reservation1 = Reservation.builder()
+                .numOfUser(3)
+                .dateTimeRange(dateTimeRange)
+                .visitor(visitorMember)
+                .facility(facility)
+                .build();
+        reservationRepository.save(reservation1);
+
+        dateTimeRange = new DateTimeRange(now, 16, now, 17);
+        Boolean isExist = reservationQueryRepository
+                .isConflictingReservation(facility, dateTimeRange);
+        assertThat(isExist).isFalse();
     }
 }

--- a/src/test/java/com/modoospace/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/modoospace/reservation/service/ReservationServiceTest.java
@@ -3,6 +3,7 @@ package com.modoospace.reservation.service;
 import com.modoospace.AbstractIntegrationContainerBaseTest;
 import com.modoospace.alarm.producer.AlarmProducer;
 import com.modoospace.common.exception.ConflictingReservationException;
+import com.modoospace.common.exception.NotOpenedFacilityException;
 import com.modoospace.common.exception.PermissionDeniedException;
 import com.modoospace.member.domain.Member;
 import com.modoospace.member.domain.MemberRepository;
@@ -54,9 +55,11 @@ public class ReservationServiceTest extends AbstractIntegrationContainerBaseTest
 
     private Member hostMember;
 
-    private Facility facility1;
+    private Facility facilityOpen9Close24;
 
-    private Facility facility2;
+    private Facility facilityOpenClose24;
+
+    private Facility facilityNotAvailable;
 
     private ReservationService reservationService;
 
@@ -120,7 +123,7 @@ public class ReservationServiceTest extends AbstractIntegrationContainerBaseTest
                         List.of(new TimeSettingCreateRequest(9, 24))
                 )
                 .build();
-        facility1 = facilityRepository.save(createRequest1.toEntity(space));
+        facilityOpen9Close24 = facilityRepository.save(createRequest1.toEntity(space));
 
         FacilityCreateRequest createRequest2 = FacilityCreateRequest.builder()
                 .name("스터디룸2")
@@ -129,15 +132,73 @@ public class ReservationServiceTest extends AbstractIntegrationContainerBaseTest
                 .maxUser(6)
                 .description("3~6인실 입니다.")
                 .build();
-        facility2 = facilityRepository.save(createRequest2.toEntity(space));
+        facilityOpenClose24 = facilityRepository.save(createRequest2.toEntity(space));
+
+        FacilityCreateRequest createRequest3 = FacilityCreateRequest.builder()
+                .name("스터디룸3")
+                .reservationEnable(false)
+                .minUser(3)
+                .maxUser(6)
+                .description("3~6인실 입니다.")
+                .build();
+        facilityNotAvailable = facilityRepository.save(createRequest3.toEntity(space));
 
         now = LocalDate.now();
+    }
+
+    @DisplayName("Visitor는 예약을 생성할 수 있다.")
+    @Test
+    public void createReservation_IfVisitor() {
+        ReservationCreateRequest createRequest = new ReservationCreateRequest(3, now, 18, now, 21);
+
+        Long reservationId = reservationService.createReservation(createRequest, facilityOpen9Close24.getId(),
+                visitorMember.getEmail());
+
+        ReservationResponse retResponse = reservationService.findReservation(reservationId,
+                visitorMember.getEmail());
+        assertAll(
+                () -> assertThat(retResponse.getId()).isEqualTo(reservationId),
+                () -> assertThat(retResponse.getFacility().getId()).isEqualTo(facilityOpen9Close24.getId()),
+                () -> assertThat(retResponse.getMember().getId()).isEqualTo(visitorMember.getId()),
+                () -> assertThat(retResponse.getStatus()).isEqualTo(ReservationStatus.WAITING)
+        );
+    }
+
+    @DisplayName("기존 예약과 시간이 겹친다면 Room은 예약할 수 없다.")
+    @Test
+    public void createReservationRoom_throwException_ifOverlappingReservation() {
+        ReservationCreateRequest createRequest = new ReservationCreateRequest(3, now, 12, now, 15);
+        reservationService.createReservation(createRequest, facilityOpen9Close24.getId(),
+                visitorMember.getEmail());
+
+        ReservationCreateRequest createRequest2 = new ReservationCreateRequest(3, now, 13, now, 15);
+        assertThatThrownBy(() -> reservationService
+                .createReservation(createRequest2, facilityOpen9Close24.getId(), visitorMember.getEmail()))
+                .isInstanceOf(ConflictingReservationException.class);
+    }
+
+    @DisplayName("예약이 불가능한 Room은 예약할 수 없다.")
+    @Test
+    public void createReservationRoom_throwException_ifNotAvailable() {
+        ReservationCreateRequest createRequest = new ReservationCreateRequest(3, now, 12, now, 15);
+        assertThatThrownBy(() -> reservationService.createReservation(createRequest, facilityNotAvailable.getId(),
+                visitorMember.getEmail()))
+                .isInstanceOf(NotOpenedFacilityException.class);
+    }
+
+    @DisplayName("Open되지 않은 시간은 예약할 수 없다.")
+    @Test
+    public void createReservationRoom_throwException_ifNotOpen() {
+        ReservationCreateRequest createRequest = new ReservationCreateRequest(3, now, 6, now, 9);
+        assertThatThrownBy(() -> reservationService.createReservation(createRequest, facilityOpen9Close24.getId(),
+                visitorMember.getEmail()))
+                .isInstanceOf(NotOpenedFacilityException.class);
     }
 
     @DisplayName("예약가능한 시간을 조회한다.(9시~24시)")
     @Test
     public void getAvailabilityTime() {
-        AvailabilityTimeResponse retResponse = reservationService.getAvailabilityTime(facility1.getId(),
+        AvailabilityTimeResponse retResponse = reservationService.getAvailabilityTime(facilityOpen9Close24.getId(),
                 now);
 
         // 9~23
@@ -149,7 +210,7 @@ public class ReservationServiceTest extends AbstractIntegrationContainerBaseTest
     @DisplayName("예약가능한 시간을 조회한다.(0시~24시)")
     @Test
     public void getAvailabilityTime_24Open() {
-        AvailabilityTimeResponse retResponse = reservationService.getAvailabilityTime(facility2.getId(),
+        AvailabilityTimeResponse retResponse = reservationService.getAvailabilityTime(facilityOpenClose24.getId(),
                 LocalDate.now());
 
         // 0~23
@@ -163,10 +224,10 @@ public class ReservationServiceTest extends AbstractIntegrationContainerBaseTest
     public void getAvailableTimes_ifPresentReservation() {
         ReservationCreateRequest createRequest = new ReservationCreateRequest(3, now, 12, now, 15);
 
-        reservationService.createReservation(createRequest, facility1.getId(),
+        reservationService.createReservation(createRequest, facilityOpen9Close24.getId(),
                 visitorMember.getEmail());
 
-        AvailabilityTimeResponse retResponse = reservationService.getAvailabilityTime(facility1.getId(),
+        AvailabilityTimeResponse retResponse = reservationService.getAvailabilityTime(facilityOpen9Close24.getId(),
                 LocalDate.now());
 
         // 9시 ~ 12시, 15시 ~ 24시
@@ -175,48 +236,78 @@ public class ReservationServiceTest extends AbstractIntegrationContainerBaseTest
                 .hasSize(15 - 3);
     }
 
-    @DisplayName("Visitor는 예약을 생성할 수 있다.")
+
+    @DisplayName("본인이 생성한 예약을 조회할 수 있다.")
     @Test
-    public void createReservation_IfVisitor() {
-        ReservationCreateRequest createRequest = new ReservationCreateRequest(3, now, 18, now, 21);
+    public void findReservation_ByVisitor() {
+        ReservationCreateRequest createRequest = new ReservationCreateRequest(3, now, 12, now, 15);
+        Long reservationId = reservationService
+                .createReservation(createRequest, facilityOpen9Close24.getId(), visitorMember.getEmail());
 
-        Long reservationId = reservationService.createReservation(createRequest, facility1.getId(),
-                visitorMember.getEmail());
+        ReservationResponse retResponse = reservationService.findReservation(reservationId, visitorMember.getEmail());
 
-        ReservationResponse retResponse = reservationService.findReservation(reservationId,
-                visitorMember.getEmail());
         assertAll(
                 () -> assertThat(retResponse.getId()).isEqualTo(reservationId),
-                () -> assertThat(retResponse.getFacility().getId()).isEqualTo(facility1.getId()),
-                () -> assertThat(retResponse.getMember().getId()).isEqualTo(visitorMember.getId()),
-                () -> assertThat(retResponse.getStatus()).isEqualTo(ReservationStatus.WAITING)
+                () -> assertThat(retResponse.getMember().getEmail()).isEqualTo(visitorMember.getEmail())
         );
     }
 
-    @DisplayName("기존 예약과 시간이 겹친다면 Room은 예약할 수 없다.")
+    @DisplayName("호스트는 본인의 시설에 생성된 예약을 조회할 수 있다.")
     @Test
-    public void createReservationRoom_throwException_ifOverlappingReservation() {
+    public void findReservation_ByHost() {
         ReservationCreateRequest createRequest = new ReservationCreateRequest(3, now, 12, now, 15);
-        reservationService.createReservation(createRequest, facility1.getId(),
-                visitorMember.getEmail());
+        Long reservationId = reservationService
+                .createReservation(createRequest, facilityOpen9Close24.getId(), visitorMember.getEmail());
 
-        ReservationCreateRequest createRequest2 = new ReservationCreateRequest(3, now, 13, now, 15);
-        assertThatThrownBy(() -> reservationService
-                .createReservation(createRequest2, facility1.getId(), visitorMember.getEmail()))
-                .isInstanceOf(ConflictingReservationException.class);
+        ReservationResponse retResponse = reservationService.findReservation(reservationId, hostMember.getEmail());
+
+        assertAll(
+                () -> assertThat(retResponse.getId()).isEqualTo(reservationId),
+                () -> assertThat(retResponse.getMember().getEmail()).isEqualTo(visitorMember.getEmail())
+        );
+    }
+
+    @DisplayName("호스트는 본인의 시설에 생성된 예약을 승인할 수 있다.")
+    @Test
+    public void approveReservation_ByHost() {
+        ReservationCreateRequest createRequest = new ReservationCreateRequest(3, now, 12, now, 15);
+        Long reservationId = reservationService
+                .createReservation(createRequest, facilityOpen9Close24.getId(), visitorMember.getEmail());
+
+        reservationService.approveReservation(reservationId, hostMember.getEmail());
+
+        ReservationResponse retResponse = reservationService.findReservation(reservationId, hostMember.getEmail());
+        assertAll(
+                () -> assertThat(retResponse.getId()).isEqualTo(reservationId),
+                () -> assertThat(retResponse.getMember().getEmail()).isEqualTo(visitorMember.getEmail()),
+                () -> assertThat(retResponse.getStatus()).isEqualTo(ReservationStatus.COMPLETED)
+        );
+    }
+
+    @DisplayName("호스트가 아닌자가 해당 예약을 승인하려 한다면 예외가 발생한다")
+    @Test
+    public void approveReservation_throwException_IfNotHost() {
+        ReservationCreateRequest createRequest = new ReservationCreateRequest(3, now, 12, now, 15);
+        Long reservationId = reservationService
+                .createReservation(createRequest, facilityOpen9Close24.getId(), visitorMember.getEmail());
+
+        reservationService.approveReservation(reservationId, hostMember.getEmail());
+
+        assertThatThrownBy(
+                () -> reservationService.approveReservation(reservationId, visitorMember.getEmail()))
+                .isInstanceOf(PermissionDeniedException.class);
     }
 
     @DisplayName("방문자가 본인의 예약을 취소할 수 있다.")
     @Test
-    public void cancelReservation() {
+    public void cancelReservation_ByVisitor() {
         ReservationCreateRequest createRequest = new ReservationCreateRequest(3, now, 12, now, 15);
         Long reservationId = reservationService
-                .createReservation(createRequest, facility1.getId(), visitorMember.getEmail());
+                .createReservation(createRequest, facilityOpen9Close24.getId(), visitorMember.getEmail());
 
         reservationService.cancelReservation(reservationId, visitorMember.getEmail());
 
-        ReservationResponse retResponse = reservationService
-                .findReservation(reservationId, visitorMember.getEmail());
+        ReservationResponse retResponse = reservationService.findReservation(reservationId, visitorMember.getEmail());
         assertAll(
                 () -> assertThat(retResponse.getId()).isEqualTo(reservationId),
                 () -> assertThat(retResponse.getMember().getEmail()).isEqualTo(visitorMember.getEmail()),
@@ -229,12 +320,10 @@ public class ReservationServiceTest extends AbstractIntegrationContainerBaseTest
     public void cancelReservation_throwException_IfNotMyReservation() {
         ReservationCreateRequest createRequest = new ReservationCreateRequest(3, now, 12, now, 15);
         Long reservationId = reservationService
-                .createReservation(createRequest, facility1.getId(), visitorMember.getEmail());
+                .createReservation(createRequest, facilityOpen9Close24.getId(), visitorMember.getEmail());
 
-        assertAll(
-                () -> assertThatThrownBy(
-                        () -> reservationService.cancelReservation(reservationId, hostMember.getEmail()))
-                        .isInstanceOf(PermissionDeniedException.class)
-        );
+        assertThatThrownBy(
+                () -> reservationService.cancelReservation(reservationId, hostMember.getEmail()))
+                .isInstanceOf(PermissionDeniedException.class);
     }
 }

--- a/src/test/java/com/modoospace/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/modoospace/reservation/service/ReservationServiceTest.java
@@ -159,7 +159,7 @@ public class ReservationServiceTest extends AbstractIntegrationContainerBaseTest
         assertAll(
                 () -> assertThat(retResponse.getId()).isEqualTo(reservationId),
                 () -> assertThat(retResponse.getFacility().getId()).isEqualTo(facilityOpen9Close24.getId()),
-                () -> assertThat(retResponse.getMember().getId()).isEqualTo(visitorMember.getId()),
+                () -> assertThat(retResponse.getVisitor().getId()).isEqualTo(visitorMember.getId()),
                 () -> assertThat(retResponse.getStatus()).isEqualTo(ReservationStatus.WAITING)
         );
     }
@@ -248,7 +248,7 @@ public class ReservationServiceTest extends AbstractIntegrationContainerBaseTest
 
         assertAll(
                 () -> assertThat(retResponse.getId()).isEqualTo(reservationId),
-                () -> assertThat(retResponse.getMember().getEmail()).isEqualTo(visitorMember.getEmail())
+                () -> assertThat(retResponse.getVisitor().getEmail()).isEqualTo(visitorMember.getEmail())
         );
     }
 
@@ -263,7 +263,7 @@ public class ReservationServiceTest extends AbstractIntegrationContainerBaseTest
 
         assertAll(
                 () -> assertThat(retResponse.getId()).isEqualTo(reservationId),
-                () -> assertThat(retResponse.getMember().getEmail()).isEqualTo(visitorMember.getEmail())
+                () -> assertThat(retResponse.getVisitor().getEmail()).isEqualTo(visitorMember.getEmail())
         );
     }
 
@@ -279,7 +279,7 @@ public class ReservationServiceTest extends AbstractIntegrationContainerBaseTest
         ReservationResponse retResponse = reservationService.findReservation(reservationId, hostMember.getEmail());
         assertAll(
                 () -> assertThat(retResponse.getId()).isEqualTo(reservationId),
-                () -> assertThat(retResponse.getMember().getEmail()).isEqualTo(visitorMember.getEmail()),
+                () -> assertThat(retResponse.getVisitor().getEmail()).isEqualTo(visitorMember.getEmail()),
                 () -> assertThat(retResponse.getStatus()).isEqualTo(ReservationStatus.COMPLETED)
         );
     }
@@ -310,7 +310,7 @@ public class ReservationServiceTest extends AbstractIntegrationContainerBaseTest
         ReservationResponse retResponse = reservationService.findReservation(reservationId, visitorMember.getEmail());
         assertAll(
                 () -> assertThat(retResponse.getId()).isEqualTo(reservationId),
-                () -> assertThat(retResponse.getMember().getEmail()).isEqualTo(visitorMember.getEmail()),
+                () -> assertThat(retResponse.getVisitor().getEmail()).isEqualTo(visitorMember.getEmail()),
                 () -> assertThat(retResponse.getStatus()).isEqualTo(ReservationStatus.CANCELED)
         );
     }

--- a/src/test/java/com/modoospace/space/domain/FacilityTest.java
+++ b/src/test/java/com/modoospace/space/domain/FacilityTest.java
@@ -1,19 +1,21 @@
 package com.modoospace.space.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
+import com.modoospace.common.exception.InvalidNumOfUserException;
 import com.modoospace.common.exception.LimitNumOfUserException;
 import com.modoospace.common.exception.NotOpenedFacilityException;
 import com.modoospace.member.domain.Member;
 import com.modoospace.member.domain.Role;
-import java.time.DayOfWeek;
-import java.util.Arrays;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.time.DayOfWeek;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class FacilityTest {
 
@@ -25,57 +27,87 @@ class FacilityTest {
     @BeforeEach
     public void before() {
         Member member = Member.builder()
-            .id(1L)
-            .email("host@email")
-            .name("host")
-            .role(Role.HOST)
-            .build();
+                .id(1L)
+                .email("host@email")
+                .name("host")
+                .role(Role.HOST)
+                .build();
 
         space = Space.builder()
-            .name("슈가맨워크")
-            .host(member)
-            .build();
+                .name("슈가맨워크")
+                .host(member)
+                .build();
 
         timeSettings = Arrays.asList(
-            new TimeSetting(new TimeRange(9, 12)), new TimeSetting(new TimeRange(14, 20)));
+                new TimeSetting(new TimeRange(9, 12)), new TimeSetting(new TimeRange(14, 20)));
 
         weekdaySettings = Arrays.asList(
-            new WeekdaySetting(DayOfWeek.WEDNESDAY), new WeekdaySetting(DayOfWeek.THURSDAY),
-            new WeekdaySetting(DayOfWeek.FRIDAY), new WeekdaySetting(DayOfWeek.SATURDAY));
+                new WeekdaySetting(DayOfWeek.WEDNESDAY), new WeekdaySetting(DayOfWeek.THURSDAY),
+                new WeekdaySetting(DayOfWeek.FRIDAY), new WeekdaySetting(DayOfWeek.SATURDAY));
     }
 
     @DisplayName("시설 생성 시 TimeSetting과 WeekSetting에 맞춰 오늘 날짜로 부터 3개월간의 스케줄데이터를 생성한다.")
     @Test
     public void createFacility_24HourOpen_ifNotSelectSetting() {
         Facility facility = Facility.builder()
-            .name("4인실")
-            .minUser(2)
-            .maxUser(4)
-            .reservationEnable(true)
-            .timeSettings(new TimeSettings(timeSettings))
-            .weekdaySettings(new WeekdaySettings(weekdaySettings))
-            .space(space)
-            .build();
+                .name("4인실")
+                .minUser(2)
+                .maxUser(4)
+                .reservationEnable(true)
+                .timeSettings(new TimeSettings(timeSettings))
+                .weekdaySettings(new WeekdaySettings(weekdaySettings))
+                .space(space)
+                .build();
 
         System.out.println(facility.getSchedules());
+    }
+
+    @DisplayName("최소인원이 0보다 작으면 Exception을 던진다.")
+    @Test
+    public void createFacility_throwException_ifMinUserSmallThan0() {
+        assertThatThrownBy(() -> Facility.builder()
+                .name("4인실")
+                .minUser(-1)
+                .maxUser(4)
+                .reservationEnable(true)
+                .build()).isInstanceOf(InvalidNumOfUserException.class);
+    }
+
+    @DisplayName("최대인원이 0보다 작으면 Exception을 던진다.")
+    @Test
+    public void createFacility_throwException_ifMaxUserSmallThan0() {
+        assertThatThrownBy(() -> Facility.builder()
+                .name("4인실")
+                .minUser(1)
+                .maxUser(-1)
+                .reservationEnable(true)
+                .build()).isInstanceOf(InvalidNumOfUserException.class);
+    }
+
+    @DisplayName("최대인원이 최소인원보다 작으면 Exception을 던진다.")
+    @Test
+    public void createFacility_throwException_ifMaxUserSmallThanMinUser() {
+        assertThatThrownBy(() -> Facility.builder()
+                .name("4인실")
+                .minUser(5)
+                .maxUser(3)
+                .reservationEnable(true)
+                .build()).isInstanceOf(InvalidNumOfUserException.class);
     }
 
     @DisplayName("예약이 불가능한 상태일 경우 예외를 던진다.")
     @Test
     public void verifyReservationEnable_throwException_ifNotEnable() {
         Facility facility = Facility.builder()
-            .name("4인실")
-            .minUser(2)
-            .maxUser(4)
-            .reservationEnable(false)
-            .timeSettings(new TimeSettings(timeSettings))
-            .weekdaySettings(new WeekdaySettings(weekdaySettings))
-            .space(space)
-            .build();
+                .name("4인실")
+                .minUser(2)
+                .maxUser(4)
+                .reservationEnable(false)
+                .build();
 
         assertAll(
-            () -> assertThatThrownBy(facility::verifyReservationEnable).isInstanceOf(
-                NotOpenedFacilityException.class)
+                () -> assertThatThrownBy(facility::verifyReservationEnable).isInstanceOf(
+                        NotOpenedFacilityException.class)
         );
     }
 
@@ -83,20 +115,17 @@ class FacilityTest {
     @Test
     public void verityNumOfUser_throwException_ifBigOrSmallUserNum() {
         Facility facility = Facility.builder()
-            .name("4인실")
-            .minUser(2)
-            .maxUser(4)
-            .reservationEnable(false)
-            .timeSettings(new TimeSettings(timeSettings))
-            .weekdaySettings(new WeekdaySettings(weekdaySettings))
-            .space(space)
-            .build();
+                .name("4인실")
+                .minUser(2)
+                .maxUser(4)
+                .reservationEnable(false)
+                .build();
 
         assertAll(
-            () -> assertThatThrownBy(() -> facility.verityNumOfUser(1)).isInstanceOf(
-                LimitNumOfUserException.class),
-            () -> assertThatThrownBy(() -> facility.verityNumOfUser(5)).isInstanceOf(
-                LimitNumOfUserException.class)
+                () -> assertThatThrownBy(() -> facility.verityNumOfUser(1)).isInstanceOf(
+                        LimitNumOfUserException.class),
+                () -> assertThatThrownBy(() -> facility.verityNumOfUser(5)).isInstanceOf(
+                        LimitNumOfUserException.class)
         );
     }
 
@@ -104,14 +133,12 @@ class FacilityTest {
     @Test
     public void getFacilityName() {
         Facility facility = Facility.builder()
-            .name("4인실")
-            .minUser(2)
-            .maxUser(4)
-            .reservationEnable(false)
-            .timeSettings(new TimeSettings(timeSettings))
-            .weekdaySettings(new WeekdaySettings(weekdaySettings))
-            .space(space)
-            .build();
+                .name("4인실")
+                .minUser(2)
+                .maxUser(4)
+                .reservationEnable(false)
+                .space(space)
+                .build();
 
         assertThat(facility.getFacilityName()).isEqualTo("슈가맨워크(4인실)");
     }

--- a/src/test/java/com/modoospace/space/domain/SchedulesTest.java
+++ b/src/test/java/com/modoospace/space/domain/SchedulesTest.java
@@ -1,17 +1,19 @@
 package com.modoospace.space.domain;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import com.modoospace.common.exception.ConflictingTimeException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class SchedulesTest {
 
@@ -20,25 +22,46 @@ class SchedulesTest {
     public void createFacilitySchedules() {
         TimeSettings timeSettings = createTimeSetting(new TimeRange(0, 24));
         WeekdaySettings weekDaySetting = createWeekDaySetting(DayOfWeek.MONDAY, DayOfWeek.TUESDAY,
-            DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY);
+                DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY);
         Schedules schedules = Schedules
-            .create3MonthSchedules(timeSettings, weekDaySetting, YearMonth.now());
+                .create3MonthSchedules(timeSettings, weekDaySetting, YearMonth.now());
 
         System.out.println(schedules);
     }
 
     private TimeSettings createTimeSetting(TimeRange... timeRanges) {
         List<TimeSetting> timeSettings = Arrays.stream(timeRanges)
-            .map(TimeSetting::new)
-            .collect(Collectors.toList());
+                .map(TimeSetting::new)
+                .collect(Collectors.toList());
         return new TimeSettings(timeSettings);
     }
 
     private WeekdaySettings createWeekDaySetting(DayOfWeek... dayOfWeeks) {
         List<WeekdaySetting> weekdaySettings = Arrays.stream(dayOfWeeks)
-            .map(WeekdaySetting::new)
-            .collect(Collectors.toList());
+                .map(WeekdaySetting::new)
+                .collect(Collectors.toList());
         return new WeekdaySettings(weekdaySettings);
+    }
+
+    @DisplayName("스케줄들의 시설을 세팅한다.")
+    @Test
+    public void setFacility() {
+        TimeSettings timeSettings = createTimeSetting(new TimeRange(0, 24));
+        WeekdaySettings weekDaySetting = createWeekDaySetting(DayOfWeek.MONDAY, DayOfWeek.TUESDAY,
+                DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY, DayOfWeek.FRIDAY);
+        Facility facility = Facility.builder()
+                .name("4인실")
+                .minUser(2)
+                .maxUser(4)
+                .reservationEnable(true)
+                .timeSettings(timeSettings)
+                .weekdaySettings(weekDaySetting)
+                .build();
+        Schedules schedules = facility.getSchedules();
+
+        schedules.setFacility(facility);
+
+        assertThat(schedules.getSchedules().get(0).getFacility()).isEqualTo(facility);
     }
 
     @DisplayName("시설 스케줄을 추가한다.")
@@ -51,8 +74,8 @@ class SchedulesTest {
 
         Schedule retSchedule = schedules.getSchedules().get(1);
         assertAll(
-            () -> retSchedule.getStartHour().equals(13),
-            () -> retSchedule.getEndHour().equals(14)
+                () -> assertThat(retSchedule.getStartHour()).isEqualTo(13),
+                () -> assertThat(retSchedule.getEndHour()).isEqualTo(14)
         );
     }
 
@@ -66,8 +89,8 @@ class SchedulesTest {
 
         Schedule retSchedule = schedules.getSchedules().get(0);
         assertAll(
-            () -> retSchedule.getStartHour().equals(9),
-            () -> retSchedule.getEndHour().equals(14)
+                () -> assertThat(retSchedule.getStartHour()).isEqualTo(9),
+                () -> assertThat(retSchedule.getEndHour()).isEqualTo(14)
         );
     }
 
@@ -75,15 +98,15 @@ class SchedulesTest {
     @Test
     public void addFacilitySchedule_Merge2() {
         Schedules schedules = createSchedules(createNowDateSchedule(9, 12),
-            createNowDateSchedule(13, 18));
+                createNowDateSchedule(13, 18));
         Schedule addSchedule = createNowDateSchedule(12, 13);
 
         schedules.add(addSchedule);
 
         Schedule retSchedule = schedules.getSchedules().get(0);
         assertAll(
-            () -> retSchedule.getStartHour().equals(9),
-            () -> retSchedule.getEndHour().equals(18)
+                () -> assertThat(retSchedule.getStartHour()).isEqualTo(9),
+                () -> assertThat(retSchedule.getEndHour()).isEqualTo(18)
         );
     }
 
@@ -94,7 +117,7 @@ class SchedulesTest {
         Schedule addSchedule = createNowDateSchedule(11, 13);
 
         assertThatThrownBy(() -> schedules.add(addSchedule))
-            .isInstanceOf(ConflictingTimeException.class);
+                .isInstanceOf(ConflictingTimeException.class);
     }
 
     @DisplayName("시설 스케줄을 업데이트 한다.")
@@ -107,10 +130,10 @@ class SchedulesTest {
 
         schedules.update(updateSchedule, schedule2);
 
-        Schedule retSchedule = schedules.getSchedules().get(0);
+        Schedule retSchedule = schedules.getSchedules().get(1);
         assertAll(
-            () -> retSchedule.getStartHour().equals(13),
-            () -> retSchedule.getEndHour().equals(18)
+                () -> assertThat(retSchedule.getStartHour()).isEqualTo(13),
+                () -> assertThat(retSchedule.getEndHour()).isEqualTo(18)
         );
     }
 
@@ -126,8 +149,8 @@ class SchedulesTest {
 
         Schedule retSchedule = schedules.getSchedules().get(0);
         assertAll(
-            () -> retSchedule.getStartHour().equals(9),
-            () -> retSchedule.getEndHour().equals(18)
+                () -> assertThat(retSchedule.getStartHour()).isEqualTo(9),
+                () -> assertThat(retSchedule.getEndHour()).isEqualTo(18)
         );
     }
 
@@ -140,21 +163,21 @@ class SchedulesTest {
         Schedule updateSchedule = createNowDateSchedule(11, 18);
 
         assertThatThrownBy(() -> schedules.update(updateSchedule, schedule2))
-            .isInstanceOf(ConflictingTimeException.class);
+                .isInstanceOf(ConflictingTimeException.class);
     }
 
 
     private Schedule createNowDateSchedule(Integer start, Integer end) {
         TimeRange timeRange = new TimeRange(start, end);
         return Schedule.builder()
-            .date(LocalDate.now())
-            .timeRange(timeRange)
-            .build();
+                .date(LocalDate.now())
+                .timeRange(timeRange)
+                .build();
     }
 
     private Schedules createSchedules(Schedule... schedule) {
         List<Schedule> schedules = Arrays.stream(schedule)
-            .collect(Collectors.toList());
+                .collect(Collectors.toList());
         return new Schedules(schedules);
     }
 }

--- a/src/test/java/com/modoospace/space/domain/SpaceTest.java
+++ b/src/test/java/com/modoospace/space/domain/SpaceTest.java
@@ -20,10 +20,6 @@ class SpaceTest {
     private Member hostMember;
     private Member visitorMember;
 
-    private Category category;
-
-    private Address address;
-
     @BeforeEach
     public void setUp() {
 
@@ -47,15 +43,6 @@ class SpaceTest {
                 .name("visitor")
                 .role(Role.VISITOR)
                 .build();
-
-        category = new Category("스터디 공간");
-
-        address = Address.builder()
-                .depthFirst("depthFirst")
-                .depthSecond("depthSecond")
-                .depthThird("depthThird")
-                .detailAddress("detailAddress")
-                .build();
     }
 
     @DisplayName("호스트만이 공간을 가질 수 있다.")
@@ -64,8 +51,6 @@ class SpaceTest {
         Space space = Space.builder()
                 .name("공간이름")
                 .description("테스트공간입니다.")
-                .address(address)
-                .category(category)
                 .host(hostMember)
                 .build();
 
@@ -79,15 +64,11 @@ class SpaceTest {
                 () -> assertThatThrownBy(() -> Space.builder()
                         .name("공간이름")
                         .description("테스트공간입니다.")
-                        .address(address)
-                        .category(category)
                         .host(visitorMember)
                         .build()),
                 () -> assertThatThrownBy(() -> Space.builder()
                         .name("공간이름")
                         .description("테스트공간입니다.")
-                        .address(address)
-                        .category(category)
                         .host(adminMember)
                         .build())
         );
@@ -99,8 +80,6 @@ class SpaceTest {
         Space space = Space.builder()
                 .name("공간이름")
                 .description("테스트공간입니다.")
-                .address(address)
-                .category(category)
                 .host(hostMember)
                 .build();
 
@@ -116,8 +95,6 @@ class SpaceTest {
         Space space = Space.builder()
                 .name("공간이름")
                 .description("테스트공간입니다.")
-                .address(address)
-                .category(category)
                 .host(hostMember)
                 .build();
 
@@ -137,8 +114,6 @@ class SpaceTest {
         Space space = Space.builder()
                 .name("공간이름")
                 .description("테스트공간입니다.")
-                .address(address)
-                .category(category)
                 .host(hostMember)
                 .facilities(Collections.singletonList(facility))
                 .build();

--- a/src/test/java/com/modoospace/space/domain/SpaceTest.java
+++ b/src/test/java/com/modoospace/space/domain/SpaceTest.java
@@ -1,9 +1,6 @@
 package com.modoospace.space.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
+import com.modoospace.common.exception.DeleteSpaceWithFacilitiesException;
 import com.modoospace.common.exception.PermissionDeniedException;
 import com.modoospace.member.domain.Member;
 import com.modoospace.member.domain.Role;
@@ -11,86 +8,142 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 class SpaceTest {
 
-  private Member adminMember;
-  private Member hostMember;
-  private Member visitorMember;
+    private Member adminMember;
+    private Member hostMember;
+    private Member visitorMember;
 
-  @BeforeEach
-  public void setUp() {
+    private Category category;
 
-    adminMember = Member.builder()
-        .id(1L)
-        .email("admin@email")
-        .name("admin")
-        .role(Role.ADMIN)
-        .build();
+    private Address address;
 
-    hostMember = Member.builder()
-        .id(2L)
-        .email("host@email")
-        .name("host")
-        .role(Role.HOST)
-        .build();
+    @BeforeEach
+    public void setUp() {
 
-    visitorMember = Member.builder()
-        .id(3L)
-        .email("visitor@email")
-        .name("visitor")
-        .role(Role.VISITOR)
-        .build();
-  }
+        adminMember = Member.builder()
+                .id(1L)
+                .email("admin@email")
+                .name("admin")
+                .role(Role.ADMIN)
+                .build();
 
-  @DisplayName("호스트만이 공간을 가질 수 있다.")
-  @Test
-  public void space() {
-    Space space = Space.builder()
-        .name("test")
-        .host(hostMember)
-        .build();
+        hostMember = Member.builder()
+                .id(2L)
+                .email("host@email")
+                .name("host")
+                .role(Role.HOST)
+                .build();
 
-    assertThat(space.getHost()).isEqualTo(hostMember);
-  }
+        visitorMember = Member.builder()
+                .id(3L)
+                .email("visitor@email")
+                .name("visitor")
+                .role(Role.VISITOR)
+                .build();
 
-  @DisplayName("호스트가 아닐 경우 공간을 가질 수 없다.")
-  @Test
-  public void space_throwException_IfNotHost() {
-    assertAll(
-        () -> assertThatThrownBy(() -> Space.builder()
-            .name("test")
-            .host(visitorMember)
-            .build()),
-        () -> assertThatThrownBy(() -> Space.builder()
-            .name("test")
-            .host(adminMember)
-            .build())
-    );
-  }
+        category = new Category("스터디 공간");
 
-  @DisplayName("공간의 주인/관리자만이 공간 수정/삭제를 할 수 있음을 검증한다.")
-  @Test
-  public void verifyManagementPermission() {
-    Space space = Space.builder()
-        .name("test")
-        .host(hostMember)
-        .build();
+        address = Address.builder()
+                .depthFirst("depthFirst")
+                .depthSecond("depthSecond")
+                .depthThird("depthThird")
+                .detailAddress("detailAddress")
+                .build();
+    }
 
-    assertAll(
-        () -> space.verifyManagementPermission(hostMember),
-        () -> space.verifyManagementPermission(adminMember)
-    );
-  }
+    @DisplayName("호스트만이 공간을 가질 수 있다.")
+    @Test
+    public void space() {
+        Space space = Space.builder()
+                .name("공간이름")
+                .description("테스트공간입니다.")
+                .address(address)
+                .category(category)
+                .host(hostMember)
+                .build();
 
-  @DisplayName("공간의 주인/관리자가 아닐 경우 공간 수정/삭제 권한 검증 시 예외를 던진다.")
-  @Test
-  public void verifyManagementPermission_throwException_ifNotPermission() {
-    Space space = Space.builder()
-        .name("test")
-        .host(hostMember)
-        .build();
+        assertThat(space.getHost()).isEqualTo(hostMember);
+    }
 
-    assertThatThrownBy(() -> space.verifyManagementPermission(visitorMember))
-        .isInstanceOf(PermissionDeniedException.class);
-  }
+    @DisplayName("호스트가 아닐 경우 공간을 가질 수 없다.")
+    @Test
+    public void space_throwException_IfNotHost() {
+        assertAll(
+                () -> assertThatThrownBy(() -> Space.builder()
+                        .name("공간이름")
+                        .description("테스트공간입니다.")
+                        .address(address)
+                        .category(category)
+                        .host(visitorMember)
+                        .build()),
+                () -> assertThatThrownBy(() -> Space.builder()
+                        .name("공간이름")
+                        .description("테스트공간입니다.")
+                        .address(address)
+                        .category(category)
+                        .host(adminMember)
+                        .build())
+        );
+    }
+
+    @DisplayName("공간의 주인/관리자만이 공간 수정/삭제를 할 수 있음을 검증한다.")
+    @Test
+    public void verifyManagementPermission() {
+        Space space = Space.builder()
+                .name("공간이름")
+                .description("테스트공간입니다.")
+                .address(address)
+                .category(category)
+                .host(hostMember)
+                .build();
+
+        assertAll(
+                () -> space.verifyManagementPermission(hostMember),
+                () -> space.verifyManagementPermission(adminMember)
+        );
+    }
+
+    @DisplayName("공간의 주인/관리자가 아닐 경우 공간 수정/삭제 권한 검증 시 예외를 던진다.")
+    @Test
+    public void verifyManagementPermission_throwException_ifNotPermission() {
+        Space space = Space.builder()
+                .name("공간이름")
+                .description("테스트공간입니다.")
+                .address(address)
+                .category(category)
+                .host(hostMember)
+                .build();
+
+        assertThatThrownBy(() -> space.verifyManagementPermission(visitorMember))
+                .isInstanceOf(PermissionDeniedException.class);
+    }
+
+    @DisplayName("삭제 권한 확인 시 해당 공간이 시설을 갖고있다면 예외를 던진다.")
+    @Test
+    public void verifyDeletePermission_throwException_ifSpaceHasFacility() {
+        Facility facility = Facility.builder()
+                .name("4인실")
+                .minUser(2)
+                .maxUser(4)
+                .reservationEnable(true)
+                .build();
+        Space space = Space.builder()
+                .name("공간이름")
+                .description("테스트공간입니다.")
+                .address(address)
+                .category(category)
+                .host(hostMember)
+                .facilities(Collections.singletonList(facility))
+                .build();
+
+        assertThatThrownBy(() -> space.verifyDeletePermission(hostMember))
+                .isInstanceOf(DeleteSpaceWithFacilitiesException.class);
+    }
 }

--- a/src/test/java/com/modoospace/space/repository/FacilityQueryRepositoryTest.java
+++ b/src/test/java/com/modoospace/space/repository/FacilityQueryRepositoryTest.java
@@ -85,14 +85,14 @@ public class FacilityQueryRepositoryTest {
     @Test
     public void searchFacility() {
         FacilitySearchRequest searchRequest = new FacilitySearchRequest();
-        searchRequest.setName("스터디");
+        searchRequest.setName("스터디룸1");
         searchRequest.setReservationEnable(true);
 
         Page<Facility> resultPage = facilityQueryRepository
                 .searchFacility(space.getId(), searchRequest, PageRequest.of(0, 10));
 
         assertThat(resultPage.getContent()).extracting("name")
-                .containsExactly("스터디룸1", "스터디룸2");
+                .containsExactly("스터디룸1");
     }
 
     @DisplayName("검색 조건에 맞는 시설이 없다면 빈 페이지를 반환한다.")
@@ -105,5 +105,17 @@ public class FacilityQueryRepositoryTest {
                 .searchFacility(space.getId(), searchRequest, PageRequest.of(0, 10));
 
         assertThat(resultPage.getContent()).isEmpty();
+    }
+
+    @DisplayName("검색 조건이 없다면, 해당 Space의 모든 시설을 반환한다.")
+    @Test
+    public void searchFacility_AllFacility() {
+        FacilitySearchRequest searchRequest = new FacilitySearchRequest();
+
+        Page<Facility> resultPage = facilityQueryRepository
+                .searchFacility(space.getId(), searchRequest, PageRequest.of(0, 10));
+
+        assertThat(resultPage.getContent()).extracting("name")
+                .containsExactly("스터디룸1", "스터디룸2");
     }
 }

--- a/src/test/java/com/modoospace/space/repository/SpaceQueryRepositoryTest.java
+++ b/src/test/java/com/modoospace/space/repository/SpaceQueryRepositoryTest.java
@@ -130,7 +130,7 @@ public class SpaceQueryRepositoryTest extends AbstractIntegrationContainerBaseTe
         now = LocalDate.now();
     }
 
-    @DisplayName("쿼리(사당)에 맞는 공간을 반환한다.")
+    @DisplayName("쿼리(사당)에 맞는 공간을 반환한다.(ElasticSearch 활용)")
     @Test
     public void searchSpace_byQuery_사당() {
         SpaceSearchRequest searchRequest = new SpaceSearchRequest();
@@ -143,7 +143,20 @@ public class SpaceQueryRepositoryTest extends AbstractIntegrationContainerBaseTe
             .containsExactly("사당 스터디룸");
     }
 
-    @DisplayName("쿼리(스터디룸)에 맞는 공간을 반환한다.")
+    @DisplayName("쿼리(사당)에 맞는 공간을 반환한다.(쿼리 활용)")
+    @Test
+    public void searchSpaceQuery_byQuery_사당() {
+        SpaceSearchRequest searchRequest = new SpaceSearchRequest();
+        searchRequest.setQuery("사당");
+
+        Page<Space> resultPage = spaceQueryRepository
+                .searchSpaceQuery(searchRequest, PageRequest.of(0, 10));
+
+        assertThat(resultPage.getContent()).extracting("name")
+                .containsExactly("사당 스터디룸");
+    }
+
+    @DisplayName("쿼리(스터디룸)에 맞는 공간을 반환한다.(ElasticSearch 활용)")
     @Test
     public void searchSpace_byQuery_스터디룸() {
         SpaceSearchRequest searchRequest = new SpaceSearchRequest();
@@ -154,6 +167,19 @@ public class SpaceQueryRepositoryTest extends AbstractIntegrationContainerBaseTe
 
         assertThat(resultPage.getContent()).extracting("name")
             .containsExactly("사당 스터디룸", "강남 스터디룸");
+    }
+
+    @DisplayName("쿼리(스터디룸)에 맞는 공간을 반환한다.(쿼리 활용)")
+    @Test
+    public void searchSpaceQuery_byQuery_스터디룸() {
+        SpaceSearchRequest searchRequest = new SpaceSearchRequest();
+        searchRequest.setQuery("스터디룸");
+
+        Page<Space> resultPage = spaceQueryRepository
+                .searchSpaceQuery(searchRequest, PageRequest.of(0, 10));
+
+        assertThat(resultPage.getContent()).extracting("name")
+                .containsExactly("사당 스터디룸", "강남 스터디룸");
     }
 
     @DisplayName("지역에 맞는 공간을 반환한다.")


### PR DESCRIPTION
## 개요
testcoverage 80%를 넘길 수 있도록 테스트 케이스를 추가하였습니다. 또한 SseEmitter를 테스트할 수 있도록 페이지 구성 및 api를 추가하였습니다. 

## 작업사항
- TestCase 추가 및 의미없는 동적쿼리제거
- SseEmitter를 subscribe하여 알림탭을 띄울 수 있도록 index 화면 재구성
- event send api 추가 (테스트용)

> 추후 Last-Event-ID 구현 필요. (유실된 데이터 전송)

참고 : https://velog.io/@max9106/Spring-SSE-Server-Sent-Events%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EC%8B%A4%EC%8B%9C%EA%B0%84-%EC%95%8C%EB%A6%BC

## 변경로직
- SseEmitter Redis저장 -> 로컬맵저장 방식으로 변경

> ObjectMapper로 직렬화하여 저장하는 방식이 겉보기엔 정상적으로 동작하는 것 처럼 보였지만, 실제로는 Client와의 연결정보를 상실(또는 불일치)하여  Event를 send해도 Client는 받지 못함. 따라서 LocalMap에 저장하도록 변경함.

