### PR TITLE
[#73] Redis Pub/Sub 구현

### DIFF
--- a/src/main/java/com/modoospace/alarm/consumer/AlarmConsumer.java
+++ b/src/main/java/com/modoospace/alarm/consumer/AlarmConsumer.java
@@ -25,7 +25,7 @@ public class AlarmConsumer {
             AlarmEvent alarmEvent = objectMapper.readValue(message, AlarmEvent.class);
             alarmService.saveAndSend(alarmEvent);
         } catch (JsonProcessingException e) {
-            throw new MessageParsingError();
+            throw new MessageParsingError(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/modoospace/alarm/controller/AlarmController.java
+++ b/src/main/java/com/modoospace/alarm/controller/AlarmController.java
@@ -3,13 +3,19 @@ package com.modoospace.alarm.controller;
 import com.modoospace.alarm.controller.dto.AlarmResponse;
 import com.modoospace.alarm.domain.AlarmType;
 import com.modoospace.alarm.service.AlarmService;
+import com.modoospace.alarm.service.RedisMessageService;
 import com.modoospace.config.auth.resolver.LoginMember;
 import com.modoospace.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RequiredArgsConstructor
@@ -18,11 +24,12 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class AlarmController {
 
     private final AlarmService alarmService;
+    private final RedisMessageService redisMessageService;
 
 
     @GetMapping()
     public ResponseEntity<Page<AlarmResponse>> search(@LoginMember Member loginMember,
-                                                      Pageable pageable) {
+            Pageable pageable) {
         Page<AlarmResponse> alarms = alarmService.searchAlarms(loginMember, pageable);
         return ResponseEntity.ok().body(alarms);
     }
@@ -30,7 +37,7 @@ public class AlarmController {
 
     @DeleteMapping("/{alarmId}")
     public ResponseEntity<Void> delete(@PathVariable Long alarmId,
-                                       @LoginMember Member loginMember) {
+            @LoginMember Member loginMember) {
         alarmService.delete(alarmId, loginMember);
         return ResponseEntity.noContent().build();
     }
@@ -43,7 +50,8 @@ public class AlarmController {
 
     @PostMapping(value = "/send/{email}")
     public ResponseEntity<Void> send(@PathVariable String email) {
-        alarmService.send(email, new AlarmResponse(null, null, "테스트시설", AlarmType.NEW_RESERVATION));
+        redisMessageService.publish(email,
+                new AlarmResponse(null, null, "테스트시설", AlarmType.NEW_RESERVATION));
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/modoospace/alarm/producer/AlarmProducer.java
+++ b/src/main/java/com/modoospace/alarm/producer/AlarmProducer.java
@@ -19,7 +19,7 @@ public class AlarmProducer {
 
     public void send(AlarmEvent alarmEvent) {
         try {
-            log.info("AlarmEvent produce to x.reservation");
+            log.info("AlarmEvent produce to x.alarm.work");
             String message = objectMapper.writeValueAsString(alarmEvent);
             rabbitTemplate.convertAndSend("x.alarm.work", "", message);
         } catch (JsonProcessingException e) {

--- a/src/main/java/com/modoospace/alarm/producer/AlarmProducer.java
+++ b/src/main/java/com/modoospace/alarm/producer/AlarmProducer.java
@@ -23,7 +23,7 @@ public class AlarmProducer {
             String message = objectMapper.writeValueAsString(alarmEvent);
             rabbitTemplate.convertAndSend("x.alarm.work", "", message);
         } catch (JsonProcessingException e) {
-            throw new MessageParsingError();
+            throw new MessageParsingError(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/modoospace/alarm/publisher/RedisPublisher.java
+++ b/src/main/java/com/modoospace/alarm/publisher/RedisPublisher.java
@@ -1,0 +1,25 @@
+package com.modoospace.alarm.publisher;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.modoospace.common.exception.MessageParsingError;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class RedisPublisher {
+
+    private final ObjectMapper objectMapper;
+    private final StringRedisTemplate redisTemplate;
+
+    public void publish(String channel, Object data) {
+        try {
+            String message = objectMapper.writeValueAsString(data);
+            redisTemplate.convertAndSend(channel, message);
+        } catch (JsonProcessingException e) {
+            throw new MessageParsingError(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/modoospace/alarm/repository/EmitterMemoryRepository.java
+++ b/src/main/java/com/modoospace/alarm/repository/EmitterMemoryRepository.java
@@ -1,18 +1,18 @@
 package com.modoospace.alarm.repository;
 
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-
 @Repository
 @RequiredArgsConstructor
-public class EmitterLocalCacheRepository {
+public class EmitterMemoryRepository {
 
-    private final Map<String, SseEmitter> sseEmitterMap = new HashMap<>();
+    // thread-safe한 자료구조
+    private final Map<String, SseEmitter> sseEmitterMap = new ConcurrentHashMap<>();
 
     public SseEmitter save(String id, SseEmitter sseEmitter) {
         sseEmitterMap.put(getKey(id), sseEmitter);
@@ -24,7 +24,7 @@ public class EmitterLocalCacheRepository {
     }
 
     public void delete(String id) {
-        sseEmitterMap.remove(id);
+        sseEmitterMap.remove(getKey(id));
     }
 
     private String getKey(String id) {

--- a/src/main/java/com/modoospace/alarm/service/RedisMessageService.java
+++ b/src/main/java/com/modoospace/alarm/service/RedisMessageService.java
@@ -1,0 +1,30 @@
+package com.modoospace.alarm.service;
+
+import com.modoospace.alarm.publisher.RedisPublisher;
+import com.modoospace.alarm.subscriber.RedisSubscribeListener;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisMessageService {
+
+    private final RedisMessageListenerContainer redisMessageListenerContainer;
+    private final RedisPublisher redisPublisher;
+    private final RedisSubscribeListener redisSubscribeListener;
+
+    // 채널 구독
+    public void subscribe(String channel) {
+        redisMessageListenerContainer.addMessageListener(redisSubscribeListener,
+                ChannelTopic.of(channel));
+    }
+
+    // 이벤트 발행
+    public void publish(String channel, Object message) {
+        redisPublisher.publish(channel, message);
+    }
+}

--- a/src/main/java/com/modoospace/alarm/service/SseEmitterService.java
+++ b/src/main/java/com/modoospace/alarm/service/SseEmitterService.java
@@ -1,0 +1,51 @@
+package com.modoospace.alarm.service;
+
+import com.modoospace.alarm.repository.EmitterMemoryRepository;
+import com.modoospace.common.exception.SSEConnectError;
+import java.io.IOException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class SseEmitterService {
+
+    @Value("${spring.sse.timeout}")
+    private Long timeout;
+
+    @Value("${spring.sse.name}")
+    private String name;
+
+    private final EmitterMemoryRepository emitterRepository;
+
+    public SseEmitter save(String email) {
+        return emitterRepository.save(email, new SseEmitter(timeout));
+    }
+
+    public void delete(String email) {
+        emitterRepository.delete(email);
+    }
+
+    public void sendToClient(String email, Object data) {
+        Optional<SseEmitter> optionalSseEmitter = emitterRepository.find(email);
+        optionalSseEmitter.ifPresent(sseEmitter -> send(sseEmitter, email, data));
+    }
+
+    public void send(SseEmitter emitter, String email, Object data) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(email)
+                    .name(name)
+                    .data(data));
+            log.info("SSE Send Event To: {}", email);
+        } catch (IOException exception) {
+            emitterRepository.delete(email);
+            throw new SSEConnectError(exception.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/modoospace/alarm/subscriber/RedisSubscribeListener.java
+++ b/src/main/java/com/modoospace/alarm/subscriber/RedisSubscribeListener.java
@@ -1,0 +1,38 @@
+package com.modoospace.alarm.subscriber;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.modoospace.alarm.controller.dto.AlarmResponse;
+import com.modoospace.alarm.service.SseEmitterService;
+import com.modoospace.common.exception.MessageParsingError;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class RedisSubscribeListener implements MessageListener {
+
+    private final SseEmitterService sseEmitterService;
+    private final ObjectMapper objectMapper;
+
+    // 채널 구독 객체
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+
+        try {
+            String email = new String(message.getChannel());
+            AlarmResponse alarmResponse = objectMapper.readValue(message.getBody(),
+                    AlarmResponse.class);
+            log.info("Redis Subscribe Channel: {}", email);
+            log.info("Redis Subscribe Message: {}", alarmResponse.getMessage());
+
+            sseEmitterService.sendToClient(email, alarmResponse);
+        } catch (IOException e) {
+            throw new MessageParsingError(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/modoospace/common/exception/MessageParsingError.java
+++ b/src/main/java/com/modoospace/common/exception/MessageParsingError.java
@@ -6,4 +6,8 @@ public class MessageParsingError extends RuntimeException {
     public MessageParsingError() {
         super(MESSAGE);
     }
+
+    public MessageParsingError(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/com/modoospace/common/exception/SSEConnectError.java
+++ b/src/main/java/com/modoospace/common/exception/SSEConnectError.java
@@ -2,9 +2,13 @@ package com.modoospace.common.exception;
 
 public class SSEConnectError extends RuntimeException {
 
-  private static final String MESSAGE = "알람 연결에 문제가 생겼습니다.";
+    private static final String MESSAGE = "알람 연결에 문제가 생겼습니다.";
 
-  public SSEConnectError() {
-    super(MESSAGE);
-  }
+    public SSEConnectError() {
+        super(MESSAGE);
+    }
+
+    public SSEConnectError(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/com/modoospace/config/rabbitmq/errorhandler/CustomErrorHandler.java
+++ b/src/main/java/com/modoospace/config/rabbitmq/errorhandler/CustomErrorHandler.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.ImmediateAcknowledgeAmqpException;
 import org.springframework.amqp.rabbit.listener.FatalExceptionStrategy;
+import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException;
 import org.springframework.util.ErrorHandler;
 
 @RequiredArgsConstructor
@@ -13,7 +14,7 @@ public class CustomErrorHandler implements ErrorHandler {
 
     @Override
     public void handleError(Throwable t) {
-        if (this.exceptionStrategy.isFatal(t)) {
+        if (this.exceptionStrategy.isFatal(t) && t instanceof ListenerExecutionFailedException) {
             throw new ImmediateAcknowledgeAmqpException(
                     "Fatal exception encountered. Retry is futile: " + t.getMessage(), t);
         }

--- a/src/main/java/com/modoospace/config/redis/RedisConfig.java
+++ b/src/main/java/com/modoospace/config/redis/RedisConfig.java
@@ -1,26 +1,36 @@
 package com.modoospace.config.redis;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 
 @Configuration
 public class RedisConfig {
 
-  @Value("${spring.redis.host}")
-  private String host;
-  @Value("${spring.redis.port}")
-  private int port;
-  @Value("${spring.redis.password}")
-  private String password;
+    @Value("${spring.redis.host}")
+    private String host;
+    @Value("${spring.redis.port}")
+    private int port;
+    @Value("${spring.redis.password}")
+    private String password;
 
-  @Bean
-  public RedisConnectionFactory redisConnectionFactory() {
-    RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
-    configuration.setPassword(password);
-    return new LettuceConnectionFactory(configuration);
-  }
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
+        configuration.setPassword(password);
+        return new LettuceConnectionFactory(configuration);
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            @Autowired RedisConnectionFactory redisConnectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+        return container;
+    }
 }

--- a/src/test/java/com/modoospace/alarm/publisher/RedisPublisherTest.java
+++ b/src/test/java/com/modoospace/alarm/publisher/RedisPublisherTest.java
@@ -1,0 +1,76 @@
+package com.modoospace.alarm.publisher;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.modoospace.AbstractIntegrationContainerBaseTest;
+import com.modoospace.alarm.controller.dto.AlarmResponse;
+import com.modoospace.alarm.domain.AlarmType;
+import com.modoospace.alarm.service.RedisMessageService;
+import com.modoospace.alarm.subscriber.RedisSubscribeListener;
+import com.modoospace.common.exception.MessageParsingError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.annotation.DirtiesContext.MethodMode;
+
+
+@DisplayName("RedisPublisher 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
+class RedisPublisherTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private RedisPublisher redisPublisher;
+
+    @Autowired
+    private RedisMessageService redisMessageService;
+
+    @MockBean
+    private RedisSubscribeListener redisSubscribeListener;
+
+    @BeforeEach
+    void setup() {
+        doNothing().when(redisSubscribeListener).onMessage(any(Message.class), any(byte[].class));
+    }
+
+    @Test
+    @DirtiesContext(methodMode = MethodMode.AFTER_METHOD)
+    public void 특정채널에_메시지를_발행하면_채널을_구독하고있는_Listener가_동작한다() {
+        redisMessageService.subscribe("test channel");
+
+        AlarmResponse alarmResponse = new AlarmResponse(1L, 1L, "테스트 시설",
+                AlarmType.NEW_RESERVATION);
+        redisPublisher.publish("test channel", alarmResponse);
+
+        verify(redisSubscribeListener, times(1)).onMessage(any(Message.class), any(byte[].class));
+    }
+
+    @Test
+    @DirtiesContext(methodMode = MethodMode.AFTER_METHOD)
+    public void 특정채널에_메세지발행시_직렬화에_실패하면_Exception을_던진다() {
+        redisMessageService.subscribe("test channel");
+
+        assertThatThrownBy(() -> redisPublisher.publish("test channel", new TestDto(1)))
+                .isInstanceOf(MessageParsingError.class);
+    }
+
+    static class TestDto {
+
+        private int testNum;
+
+        public TestDto(int testNum) {
+            this.testNum = testNum;
+        }
+    }
+}

--- a/src/test/java/com/modoospace/alarm/service/AlarmServiceTest.java
+++ b/src/test/java/com/modoospace/alarm/service/AlarmServiceTest.java
@@ -1,14 +1,18 @@
 package com.modoospace.alarm.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.modoospace.AbstractIntegrationContainerBaseTest;
 import com.modoospace.alarm.controller.dto.AlarmEvent;
 import com.modoospace.alarm.domain.Alarm;
 import com.modoospace.alarm.domain.AlarmRepository;
 import com.modoospace.alarm.domain.AlarmType;
-import com.modoospace.alarm.repository.EmitterLocalCacheRepository;
+import com.modoospace.alarm.repository.EmitterMemoryRepository;
 import com.modoospace.member.domain.Member;
 import com.modoospace.member.domain.MemberRepository;
 import com.modoospace.member.domain.Role;
+import java.util.Objects;
+import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,11 +22,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
-import java.util.Objects;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @Transactional
 class AlarmServiceTest extends AbstractIntegrationContainerBaseTest {
@@ -40,7 +39,7 @@ class AlarmServiceTest extends AbstractIntegrationContainerBaseTest {
     private StringRedisTemplate redisTemplate;
 
     @Autowired
-    private EmitterLocalCacheRepository emitterRepository;
+    private EmitterMemoryRepository emitterRepository;
 
     private Member hostMember;
 

--- a/src/test/java/com/modoospace/alarm/service/SseEmitterServiceTest.java
+++ b/src/test/java/com/modoospace/alarm/service/SseEmitterServiceTest.java
@@ -1,0 +1,71 @@
+package com.modoospace.alarm.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.modoospace.AbstractIntegrationContainerBaseTest;
+import com.modoospace.alarm.repository.EmitterMemoryRepository;
+import java.io.IOException;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
+
+@DisplayName("SseEmitterService 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SseEmitterServiceTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private SseEmitterService emitterService;
+
+    @Autowired
+    private EmitterMemoryRepository emitterRepository;
+
+    private String testEmail = "test@email.com";
+
+    @AfterEach
+    public void after() {
+        emitterRepository.delete(testEmail);
+    }
+
+    @Test
+    public void SseEmitter를_email을_key값으로_메모리에_저장한다() {
+        SseEmitter saveEmitter = emitterService.save(testEmail);
+
+        Optional<SseEmitter> optionalEmitter = emitterRepository.find(testEmail);
+        assertAll(
+                () -> assertThat(optionalEmitter).isPresent(),
+                () -> assertThat(optionalEmitter.get()).isEqualTo(saveEmitter)
+        );
+    }
+
+    @Test
+    public void SseEmitter는_email을_key값으로_메모리에서_삭제할수있다() {
+        emitterService.save(testEmail);
+
+        emitterService.delete(testEmail);
+
+        Optional<SseEmitter> optionalEmitter = emitterRepository.find(testEmail);
+        assertThat(optionalEmitter).isEmpty();
+    }
+
+    @Test
+    public void SseEmitter는_email을_key값으로_Client에게_데이터를_전송한다() throws IOException {
+        // SseEmitter 기능을 테스트하는 것은 무의미하므로 Mock으로 대체한다.
+        SseEmitter mockEmitter = mock(SseEmitter.class);
+        emitterRepository.save(testEmail, mockEmitter);
+
+        emitterService.sendToClient(testEmail, "testData");
+
+        verify(mockEmitter, times(1)).send(any(SseEventBuilder.class));
+    }
+}


### PR DESCRIPTION
## 개요
현재 구독된 클라이언트의 SseEmitter를 서버의 메모리(해시맵)에 저장하고 있다. 만약 서버를 이중화하게된다면, 서버끼리 공유가 되지 않기때문에 이벤트 발행 서버와 유저가 구독한 서버가 다르면 알림을 전송하지 못하는 이슈가 발생한다.

## 작업사항
![image](https://github.com/f-lab-edu/modoospace/assets/48192141/66c822ac-1468-46c7-942b-f4b5896ae7f0)

- RedisMessageListenerContainer 설정
- Redis Channel Subscriber, Publisher 생성
  - 클라이언트가 SseEmitter 구독 시,  Channel(클라이언트 이메일 ) 구독 
  - 알람 발생 시, Channel(클라이언트 이메일)에 이벤트(알람내용) Publish

## 변경로직
- Exception 생성자 추가 (전체적인 리팩토링 필요)
> 참고: [[이펙티브 자바] 아이템 75. 예외의 상세 메세지에 실패 관련 정보를 담으라](https://velog.io/@injoon2019/%EC%9D%B4%ED%8E%99%ED%8B%B0%EB%B8%8C-%EC%9E%90%EB%B0%94-%EC%95%84%EC%9D%B4%ED%85%9C-75.-%EC%98%88%EC%99%B8%EC%9D%98-%EC%83%81%EC%84%B8-%EB%A9%94%EC%8B%9C%EC%A0%9C%EC%97%90-%EC%8B%A4%ED%8C%A8-%EA%B4%80%EB%A0%A8-%EC%A0%95%EB%B3%B4%EB%A5%BC-%EB%8B%B4%EC%9C%BC%EB%9D%BC)
- SseEmitterService 클래스를 생성하여 SseEmitter관련 로직 위임
